### PR TITLE
Extend query filters

### DIFF
--- a/src/tezos/TezosConseilQuery.ts
+++ b/src/tezos/TezosConseilQuery.ts
@@ -1,183 +1,240 @@
 import {
-    OperationFees,
-    TezosAccount,
-    TezosAccountWithOperationGroups,
-    TezosBlock, TezosBlockWithOperationGroups, TezosOperation,
-    TezosOperationGroup,
-    TezosOperationGroupWithOperations
+  TezosFilter,
+  TezosBlockFilter,
+  TezosAccountFilter,
+  TezosOperationFilter
+} from "./TezosTypes";
+import {
+  OperationFees,
+  TezosAccount,
+  TezosAccountWithOperationGroups,
+  TezosBlock,
+  TezosBlockWithOperationGroups,
+  TezosOperation,
+  TezosOperationGroup,
+  TezosOperationGroupWithOperations
 } from "../utils/ConseilTypes";
-import {queryConseilServer, queryConseilServerWithFilter} from "../utils/ConseilQuery";
+import {
+  queryConseilServer,
+  queryConseilServerWithFilter
+} from "../utils/ConseilQuery";
 
 /**
  * Functions for querying the Conseil backend REST API
  */
 
-/**
- * Filter with predicates for querying Conseil server
- * Se Conseil REST API documentation for usage.
- */
-export interface TezosFilter {
-    limit: number;
-    block_id: string[];
-    block_level: number[];
-    block_netid: string[];
-    block_protocol: string[];
-    operation_id: string[];
-    operation_source: string[];
-    operation_destination: string[];
-    operation_participant: string[];
-    operation_kind: string[];
-    account_id: string[];
-    account_manager: string[];
-    account_delegate: string[];
-}
-
 export namespace TezosConseilQuery {
-    /**
-     * Convenience function for creating an empty Tezos filter which can later be overriden as desired.
-     * @returns {TezosFilter}   Empty Tezos filter
-     */
-    export function getEmptyTezosFilter(): TezosFilter {
-        return {
-            block_id: [],
-            block_level: [],
-            block_netid: [],
-            block_protocol: [],
-            operation_id: [],
-            operation_source: [],
-            operation_destination: [],
-            operation_participant: [],
-            operation_kind: [],
-            account_id: [],
-            account_manager: [],
-            account_delegate: [],
-            limit: 100
-        }
-    }
+  /**
+   * Convenience function for creating an empty Tezos filter which can later be overriden as desired.
+   * @returns {TezosBlockFilter}   Empty Tezos Block filter
+   */
+  export function getEmptyTezosBlocksFilter(): TezosBlockFilter {
+    return {
+      block_id: [],
+      block_level: [],
+      block_netid: [],
+      block_protocol: [],
+      limit: 100
+    };
+  }
+  /**
+   * Convenience function for creating an empty Tezos filter which can later be overriden as desired.
+   * @returns {TezosOperationFilter}   Empty Tezos Operation filter
+   */
+  export function getEmptyTezosOperationFilter(): TezosOperationFilter {
+    return {
+      operation_id: [],
+      operation_source: [],
+      operation_destination: [],
+      operation_participant: [],
+      operation_kind: [],
+      limit: 100
+    };
+  }
+  /**
+   * Convenience function for creating an empty Tezos filter which can later be overriden as desired.
+   * @returns {TezosAccountFilter}   Empty Tezos filter
+   */
+  export function getEmptyTezosAccountFilter(): TezosAccountFilter {
+    return {
+      account_id: [],
+      account_manager: [],
+      account_delegate: [],
+      limit: 100
+    };
+  }
 
-    /**
-     * Fetches the most recent block stored in the database.
-     * @param {string} server  Which Conseil server to go against
-     * @param apiKey    API key to use for Conseil server.
-     * @returns {Promise<TezosBlock>}   Latest block.
-     */
-    export function getBlockHead(server: string, apiKey: string): Promise<TezosBlock> {
-        return queryConseilServer(server, 'blocks/head', apiKey)
-            .then(json => {
-                return <TezosBlock> json
-            })
-    }
+  /**
+   * Fetches the most recent block stored in the database.
+   * @param {string} server  Which Conseil server to go against
+   * @param apiKey    API key to use for Conseil server.
+   * @returns {Promise<TezosBlock>}   Latest block.
+   */
+  export function getBlockHead(
+    server: string,
+    apiKey: string
+  ): Promise<TezosBlock> {
+    return queryConseilServer(server, "blocks/head", apiKey).then(json => {
+      return <TezosBlock>json;
+    });
+  }
 
-    /**
-     * Fetches a block by block hash from the db.
-     * @param {string} server  Which Conseil server to go against
-     * @param {String} hash The block's hash
-     * @param apiKey    API key to use for Conseil server.
-     * @returns {Promise<TezosBlock>}   The block
-     */
-    export function getBlock(server: string, hash: String, apiKey: string): Promise<TezosBlockWithOperationGroups> {
-        return queryConseilServer(server, `blocks/${hash}`, apiKey)
-            .then(json => {
-                return <TezosBlockWithOperationGroups> json
-            })
-    }
+  /**
+   * Fetches a block by block hash from the db.
+   * @param {string} server  Which Conseil server to go against
+   * @param {String} hash The block's hash
+   * @param apiKey    API key to use for Conseil server.
+   * @returns {Promise<TezosBlock>}   The block
+   */
+  export function getBlock(
+    server: string,
+    hash: String,
+    apiKey: string
+  ): Promise<TezosBlockWithOperationGroups> {
+    return queryConseilServer(server, `blocks/${hash}`, apiKey).then(json => {
+      return <TezosBlockWithOperationGroups>json;
+    });
+  }
 
-    /**
-     * Fetch a given operation group
-     * @param {string} server  Which Conseil server to go against
-     * @param {String} hash Operation group hash
-     * @param apiKey    API key to use for Conseil server.
-     * @returns {Promise<TezosOperationGroupWithOperations>}    Operation group along with associated operations and accounts
-     */
-    export function getOperationGroup(server: string, hash: String, apiKey: string): Promise<TezosOperationGroupWithOperations> {
-        return queryConseilServer(server, `operation_groups/${hash}`, apiKey)
-            .then(json => {
-                return <TezosOperationGroupWithOperations> json
-            })
-    }
+  /**
+   * Fetch a given operation group
+   * @param {string} server  Which Conseil server to go against
+   * @param {String} hash Operation group hash
+   * @param apiKey    API key to use for Conseil server.
+   * @returns {Promise<TezosOperationGroupWithOperations>}    Operation group along with associated operations and accounts
+   */
+  export function getOperationGroup(
+    server: string,
+    hash: String,
+    apiKey: string
+  ): Promise<TezosOperationGroupWithOperations> {
+    return queryConseilServer(server, `operation_groups/${hash}`, apiKey).then(
+      json => {
+        return <TezosOperationGroupWithOperations>json;
+      }
+    );
+  }
 
-    /**
-     * Fetches all operation groups.
-     * @param {string} server  Which Conseil server to go against
-     * @param {TezosFilter} filter  Filters to apply
-     * @param apiKey    API key to use for Conseil server.
-     * @returns {Promise<TezosOperationGroup[]>}    List of operation groups
-     */
-    export function getOperationGroups(server: string, filter: TezosFilter, apiKey: string): Promise<TezosOperationGroup[]> {
-        return queryConseilServerWithFilter(server, 'operation_groups', filter, apiKey)
-            .then(json => {
-                return <TezosOperationGroup[]> json
-            })
-    }
+  /**
+   * Fetches all operation groups.
+   * @param {string} server  Which Conseil server to go against
+   * @param {TezosOperationFilter} filter  Filters to apply
+   * @param apiKey    API key to use for Conseil server.
+   * @returns {Promise<TezosOperationGroup[]>}    List of operation groups
+   */
+  export function getOperationGroups(
+    server: string,
+    filter: TezosOperationFilter,
+    apiKey: string
+  ): Promise<TezosOperationGroup[]> {
+    return queryConseilServerWithFilter(
+      server,
+      "operation_groups",
+      filter,
+      apiKey
+    ).then(json => {
+      return <TezosOperationGroup[]>json;
+    });
+  }
 
-    /**
-     * Fetches all operations.
-     * @param {string} server  Which Conseil server to go against
-     * @param {TezosFilter} filter  Filters to apply
-     * @param apiKey    API key to use for Conseil server.
-     * @returns {Promise<TezosOperationGroup[]>}    List of operations
-     */
-    export function getOperations(server: string, filter: TezosFilter, apiKey: string): Promise<TezosOperation[]> {
-        return queryConseilServerWithFilter(server, 'operations', filter, apiKey)
-            .then(json => {
-                return <TezosOperation[]> json
-            })
-    }
+  /**
+   * Fetches all operations.
+   * @param {string} server  Which Conseil server to go against
+   * @param {TezosOperationFilter} filter  Filters to apply
+   * @param apiKey    API key to use for Conseil server.
+   * @returns {Promise<TezosOperationGroup[]>}    List of operations
+   */
+  export function getOperations(
+    server: string,
+    filter: TezosOperationFilter,
+    apiKey: string
+  ): Promise<TezosOperation[]> {
+    return queryConseilServerWithFilter(
+      server,
+      "operations",
+      filter,
+      apiKey
+    ).then(json => {
+      return <TezosOperation[]>json;
+    });
+  }
 
-    /**
-     * Fetches prevailing fees.
-     * @param {string} server  Which Conseil server to go against
-     * @param {TezosFilter} filter  Filters to apply. 'operation_kind' and 'limit' should be explicitly set for maximum accuracy.
-     * @param apiKey    API key to use for Conseil server.
-     * @returns {Promise<TezosOperationGroup[]>}    Low, medium and high fee levels.
-     */
-    export function getAverageFees(server: string, filter: TezosFilter, apiKey: string): Promise<OperationFees> {
-        return queryConseilServerWithFilter(server, 'operations/avgFees', filter, apiKey)
-            .then(json => {
-                return <OperationFees> json
-            })
-    }
+  /**
+   * Fetches prevailing fees.
+   * @param {string} server  Which Conseil server to go against
+   * @param {TezosOperationFilter} filter  Filters to apply. 'operation_kind' and 'limit' should be explicitly set for maximum accuracy.
+   * @param apiKey    API key to use for Conseil server.
+   * @returns {Promise<TezosOperationGroup[]>}    Low, medium and high fee levels.
+   */
+  export function getAverageFees(
+    server: string,
+    filter: TezosOperationFilter,
+    apiKey: string
+  ): Promise<OperationFees> {
+    return queryConseilServerWithFilter(
+      server,
+      "operations/avgFees",
+      filter,
+      apiKey
+    ).then(json => {
+      return <OperationFees>json;
+    });
+  }
 
-    /**
-     * Fetches an account by account id from the db.
-     * @param {string} server  Which Conseil server to go against
-     * @param {String} hash The account's id number
-     * @param apiKey    API key to use for Conseil server.
-     * @returns {Promise<TezosAccountWithOperationGroups>}  The account with its associated operation groups
-     */
-    export function getAccount(server: string, hash: String, apiKey: string): Promise<TezosAccountWithOperationGroups> {
-        return queryConseilServer(server, `accounts/${hash}`, apiKey)
-            .then(json => {
-                return <TezosAccountWithOperationGroups> json
-            })
-    }
-    /**
-     * Fetches all blocks from the db.
-     * @param {string} server  Which Conseil server to go against
-     * @param {TezosFilter} filter  Filters to apply
-     * @param apiKey    API key to use for Conseil server.
-     * @returns {Promise<TezosBlock[]>} List of blocks
-     */
-    export function getBlocks(server: string, filter: TezosFilter, apiKey: string): Promise<TezosBlock[]> {
-        return queryConseilServerWithFilter(server, 'blocks', filter, apiKey)
-            .then(json => {
-                return <TezosBlock[]> json
-            })
-    }
+  /**
+   * Fetches an account by account id from the db.
+   * @param {string} server  Which Conseil server to go against
+   * @param {String} hash The account's id number
+   * @param apiKey    API key to use for Conseil server.
+   * @returns {Promise<TezosAccountWithOperationGroups>}  The account with its associated operation groups
+   */
+  export function getAccount(
+    server: string,
+    hash: String,
+    apiKey: string
+  ): Promise<TezosAccountWithOperationGroups> {
+    return queryConseilServer(server, `accounts/${hash}`, apiKey).then(json => {
+      return <TezosAccountWithOperationGroups>json;
+    });
+  }
+  /**
+   * Fetches all blocks from the db.
+   * @param {string} server  Which Conseil server to go against
+   * @param {TezosBlockFilter} filter  Filters to apply
+   * @param apiKey    API key to use for Conseil server.
+   * @returns {Promise<TezosBlock[]>} List of blocks
+   */
+  export function getBlocks(
+    server: string,
+    filter: TezosBlockFilter,
+    apiKey: string
+  ): Promise<TezosBlock[]> {
+    return queryConseilServerWithFilter(server, "blocks", filter, apiKey).then(
+      json => {
+        return <TezosBlock[]>json;
+      }
+    );
+  }
 
-
-
-    /**
-     * Fetches a list of accounts from the db.
-     * @param {string} server  Which Tezos network to go against
-     * @param {TezosFilter} filter  Filters to apply
-     * @param apiKey    API key to use for Conseil server.
-     * @returns {Promise<TezosAccount[]>}   List of accounts
-     */
-    export function getAccounts(server: string, filter: TezosFilter, apiKey: string): Promise<TezosAccount[]> {
-        return queryConseilServerWithFilter(server, 'accounts', filter, apiKey)
-            .then(json => {
-                return <TezosAccount[]> json
-            })
-    }
+  /**
+   * Fetches a list of accounts from the db.
+   * @param {string} server  Which Tezos network to go against
+   * @param {TezosAccountFilter} filter  Filters to apply
+   * @param apiKey    API key to use for Conseil server.
+   * @returns {Promise<TezosAccount[]>}   List of accounts
+   */
+  export function getAccounts(
+    server: string,
+    filter: TezosAccountFilter,
+    apiKey: string
+  ): Promise<TezosAccount[]> {
+    return queryConseilServerWithFilter(
+      server,
+      "accounts",
+      filter,
+      apiKey
+    ).then(json => {
+      return <TezosAccount[]>json;
+    });
+  }
 }

--- a/src/tezos/TezosTypes.ts
+++ b/src/tezos/TezosTypes.ts
@@ -64,3 +64,43 @@ export interface AlphaOperationsWithMetadata {
 export interface InjectedOperation {
     injectedOperation: string
 }
+
+export enum OperationKindFilter {
+    SeedNonceRevelation = "seed_nonce_revelation",
+    Delegation = "delegation",
+    Transaction = "transaction",
+    ActivateAccount = "activate_account",
+    Origination = "origination",
+    Reveal = "reveal",
+    Endorsement = "endorsement",
+}
+
+export interface TezosBlockFilter {
+  limit: number;
+  block_id: string[];
+  block_level: number[];
+  block_netid: string[];
+  block_protocol: string[];
+}
+
+export interface TezosAccountFilter {
+  limit: number;
+  account_id: string[];
+  account_manager: string[];
+  account_delegate: string[];
+}
+
+export interface TezosOperationFilter {
+  limit: number;
+  operation_id: string[];
+  operation_source: string[];
+  operation_destination: string[];
+  operation_participant: string[];
+  operation_kind: OperationKindFilter[];
+}
+
+/**
+ * Filter with predicates for querying Conseil server
+ * Se Conseil REST API documentation for usage.
+ */
+export type TezosFilter = TezosBlockFilter | TezosAccountFilter | TezosAccountFilter;

--- a/src/utils/ConseilQuery.ts
+++ b/src/utils/ConseilQuery.ts
@@ -1,6 +1,6 @@
 import * as querystring from "querystring";
-import fetch from 'node-fetch';
-import {TezosFilter} from "..";
+import fetch from "node-fetch";
+import { TezosFilter } from "../tezos/TezosTypes";
 
 /**
  * Utility functions for querying backend Conseil API
@@ -14,16 +14,21 @@ import {TezosFilter} from "..";
  * @param {string} apiKey    API key to use for Conseil server.
  * @returns {Promise<object>}   JSON representation of response from Conseil
  */
-export function queryConseilServer(server: string, route: string, apiKey: string): Promise<object> {
-    const url = `${server}/${route}`;
-    console.log(`Querying Conseil server at URL ${url}`);
-    return fetch(url, {
-        method: 'get',
-        headers: {
-            "apiKey": apiKey
-        }
-    })
-        .then(response => {return response.json()});
+export function queryConseilServer(
+  server: string,
+  route: string,
+  apiKey: string
+): Promise<object> {
+  const url = `${server}/${route}`;
+  console.log(`Querying Conseil server at URL ${url}`);
+  return fetch(url, {
+    method: "get",
+    headers: {
+      apiKey: apiKey
+    }
+  }).then(response => {
+    return response.json();
+  });
 }
 
 /**
@@ -34,10 +39,15 @@ export function queryConseilServer(server: string, route: string, apiKey: string
  * @param {string} apiKey    API key to use for Conseil server.
  * @returns {Promise<object>}   Data returned by Conseil as a JSON object
  */
-export function queryConseilServerWithFilter(server: string, route: string, filter: TezosFilter, apiKey: string): Promise<object> {
-    let params = querystring.stringify(sanitizeFilter(filter));
-    let cmdWithParams = `${route}?${params}`;
-    return queryConseilServer(server, cmdWithParams, apiKey);
+export function queryConseilServerWithFilter(
+  server: string,
+  route: string,
+  filter: TezosFilter,
+  apiKey: string
+): Promise<object> {
+  const params = querystring.stringify(sanitizeFilter(filter));
+  const cmdWithParams = `${route}?${params}`;
+  return queryConseilServer(server, cmdWithParams, apiKey);
 }
 
 /**
@@ -45,20 +55,8 @@ export function queryConseilServerWithFilter(server: string, route: string, filt
  * @param {TezosFilter} filter  Conseil filter
  * @returns {TezosFilter}   Sanitized Conseil filter
  */
-function sanitizeFilter(filter: TezosFilter): TezosFilter {
-    return {
-        limit: filter.limit,
-        block_id: filter.block_id.filter(Boolean),
-        block_level: filter.block_level.filter(Boolean),
-        block_netid: filter.block_netid.filter(Boolean),
-        block_protocol: filter.block_protocol.filter(Boolean),
-        operation_id: filter.operation_id.filter(Boolean),
-        operation_source: filter.operation_source.filter(Boolean),
-        operation_destination: filter.operation_source.filter(Boolean),
-        operation_participant: filter.operation_participant.filter(Boolean),
-        operation_kind: filter.operation_kind.filter(Boolean),
-        account_id: filter.account_id.filter(Boolean),
-        account_manager: filter.account_manager.filter(Boolean),
-        account_delegate: filter.account_delegate.filter(Boolean)
-    };
+function sanitizeFilter(filter: TezosFilter): object {
+  return Object.keys(filter)
+    .filter((key: string) => filter[key].filter(Boolean))
+    .map((key: string) => filter[key]);
 }

--- a/test/TezosConseilQuery.spec.ts
+++ b/test/TezosConseilQuery.spec.ts
@@ -1,63 +1,127 @@
-import 'mocha';
-import {expect} from 'chai';
-import {TezosConseilQuery} from '../src'
-import {servers} from "./servers";
+import "mocha";
+import { expect } from "chai";
+import { TezosConseilQuery } from "../src";
+import { OperationKindFilter } from "../src/tezos/TezosTypes";
+import { servers } from "./servers";
 
 const conseilURL = servers.conseilServer;
 const conseilApiKey = servers.conseilApiKey;
 
-describe('Block fetchers', () => {
-    it('should correctly fetch blocks', async () => {
-        const head = await TezosConseilQuery.getBlockHead(conseilURL, conseilApiKey);
-        expect(head.hash.startsWith('B')).to.equal(true);
-        const aBlock = await TezosConseilQuery.getBlock(conseilURL, head.hash, conseilApiKey);
-        expect(aBlock.block.hash).to.equal(head.hash);
-    });
+describe("Block fetchers", () => {
+  it("should correctly fetch blocks", async () => {
+    const head = await TezosConseilQuery.getBlockHead(
+      conseilURL,
+      conseilApiKey
+    );
+    expect(head.hash.startsWith("B")).to.equal(true);
+    const aBlock = await TezosConseilQuery.getBlock(
+      conseilURL,
+      head.hash,
+      conseilApiKey
+    );
+    expect(aBlock.block.hash).to.equal(head.hash);
+  });
 });
 
-describe('Operation fetchers', () => {
-    it('should correctly fetch operations', async () => {
-        const emptyFilter = TezosConseilQuery.getEmptyTezosFilter();
-        const opFilter = {...emptyFilter, limit: 10, operation_kind: ['transaction']};
-        const ops = await TezosConseilQuery.getOperations(conseilURL, opFilter, conseilApiKey);
-        expect(ops.length).to.equal(10);
-        const opGroup = await TezosConseilQuery.getOperationGroup(conseilURL, ops[0].operationGroupHash, conseilApiKey);
-        expect(opGroup.operation_group.hash).to.equal(ops[0].operationGroupHash);
-        const opGroupsFilter = {...emptyFilter, limit: 10, operation_id: [opGroup.operation_group.hash]};
-        const opGroups = await TezosConseilQuery.getOperationGroups(conseilURL, opGroupsFilter, conseilApiKey);
-        expect(opGroups.length).to.equal(1)
-    });
+describe("Operation fetchers", () => {
+  it("should correctly fetch operations", async () => {
+    const emptyFilter = TezosConseilQuery.getEmptyTezosOperationFilter();
+    const opFilter = {
+      ...emptyFilter,
+      limit: 10,
+      operation_kind: [OperationKindFilter.Transaction]
+    };
+    const ops = await TezosConseilQuery.getOperations(
+      conseilURL,
+      opFilter,
+      conseilApiKey
+    );
+    expect(ops.length).to.equal(10);
+    const opGroup = await TezosConseilQuery.getOperationGroup(
+      conseilURL,
+      ops[0].operationGroupHash,
+      conseilApiKey
+    );
+    expect(opGroup.operation_group.hash).to.equal(ops[0].operationGroupHash);
+    const opGroupsFilter = {
+      ...emptyFilter,
+      limit: 10,
+      operation_id: [opGroup.operation_group.hash]
+    };
+    const opGroups = await TezosConseilQuery.getOperationGroups(
+      conseilURL,
+      opGroupsFilter,
+      conseilApiKey
+    );
+    expect(opGroups.length).to.equal(1);
+  });
 });
 
-describe('Account fetchers', () => {
-    it('should correctly fetch accounts', async () => {
-        const emptyFilter = TezosConseilQuery.getEmptyTezosFilter();
-        const accountsFilter = {...emptyFilter, limit: 10};
-        const accounts = await TezosConseilQuery.getAccounts(conseilURL, accountsFilter, conseilApiKey);
-        expect(accounts.length).to.equal(10);
-        const account = await TezosConseilQuery.getAccount(conseilURL, accounts[0].accountId, conseilApiKey);
-        expect(account.account.accountId).to.equal(accounts[0].accountId)
-    });
+describe("Account fetchers", () => {
+  it("should correctly fetch accounts", async () => {
+    const emptyFilter = TezosConseilQuery.getEmptyTezosAccountFilter();
+    const accountsFilter = { ...emptyFilter, limit: 10 };
+    const accounts = await TezosConseilQuery.getAccounts(
+      conseilURL,
+      accountsFilter,
+      conseilApiKey
+    );
+    expect(accounts.length).to.equal(10);
+    const account = await TezosConseilQuery.getAccount(
+      conseilURL,
+      accounts[0].accountId,
+      conseilApiKey
+    );
+    expect(account.account.accountId).to.equal(accounts[0].accountId);
+  });
 });
 
-describe('Transaction fetchers', () => {
-    it('should correctly fetch operations', async () => {
-        const emptyFilter = TezosConseilQuery.getEmptyTezosFilter();
-        const opFilter = {...emptyFilter, limit: 10, operation_kind: ['transaction']};
-        const ops = await TezosConseilQuery.getOperations(conseilURL, opFilter, conseilApiKey);
-        expect(ops.length).to.equal(10);
-        const account = ops[0].source;
-        const transFilter = {...emptyFilter, limit: 10, operation_participant: [account], operation_kind: ['transaction']};
-        const transactions = await TezosConseilQuery.getOperations(conseilURL, transFilter, conseilApiKey);
-        expect(transactions[0].source == account || transactions[0].destination == account).to.equal(true)
-    });
+describe("Transaction fetchers", () => {
+  it("should correctly fetch operations", async () => {
+    const emptyFilter = TezosConseilQuery.getEmptyTezosOperationFilter();
+    const opFilter = {
+      ...emptyFilter,
+      limit: 10,
+      operation_kind: [OperationKindFilter.Transaction]
+    };
+    const ops = await TezosConseilQuery.getOperations(
+      conseilURL,
+      opFilter,
+      conseilApiKey
+    );
+    expect(ops.length).to.equal(10);
+    const account = ops[0].source;
+    const transFilter = {
+      ...emptyFilter,
+      limit: 10,
+      operation_participant: [account],
+      operation_kind: [OperationKindFilter.Transaction]
+    };
+    const transactions = await TezosConseilQuery.getOperations(
+      conseilURL,
+      transFilter,
+      conseilApiKey
+    );
+    expect(
+      transactions[0].source == account ||
+        transactions[0].destination == account
+    ).to.equal(true);
+  });
 });
 
-describe('getAverageFees()', () => {
-    it('should correctly fetch prevailing fees', async () => {
-        const emptyFilter = TezosConseilQuery.getEmptyTezosFilter();
-        const feeFilter = {...emptyFilter, limit: 10, operation_kind: ['transaction']};
-        const fees = await TezosConseilQuery.getAverageFees(conseilURL, feeFilter, conseilApiKey);
-        expect(fees.low > 0).to.equal(true);
-    });
+describe("getAverageFees()", () => {
+  it("should correctly fetch prevailing fees", async () => {
+    const emptyFilter = TezosConseilQuery.getEmptyTezosOperationFilter();
+    const feeFilter = {
+      ...emptyFilter,
+      limit: 10,
+      operation_kind: [OperationKindFilter.Transaction]
+    };
+    const fees = await TezosConseilQuery.getAverageFees(
+      conseilURL,
+      feeFilter,
+      conseilApiKey
+    );
+    expect(fees.low > 0).to.equal(true);
+  });
 });


### PR DESCRIPTION
There is no point to display / send filters that are not used in particular view / endpoint, that's why splitting global object `TezosFilters` was required. This PR is related to https://github.com/Cryptonomic/Arronax/issues/56 task, there was a need to add `operation_kind` filter, and when i was passing it to endpoint that was not related to `operations` i had 500 error from API - afaik its already fixed, but still there is no need to pass/display unnecessary filter parameters.