### PR TITLE
Made reveal operations zero fee

### DIFF
--- a/src/tezos/TezosOperations.ts
+++ b/src/tezos/TezosOperations.ts
@@ -194,7 +194,6 @@ export namespace TezosOperations {
     export async function appendRevealOperation(
         network: string,
         keyStore: KeyStore,
-        fee: number,
         account: TezosTypes.Account,
         operations: Operation[]
     ) {
@@ -204,7 +203,7 @@ export namespace TezosOperations {
             const revealOp: Operation = {
                 kind: "reveal",
                 source: keyStore.publicKeyHash,
-                fee: fee.toString(),
+                fee: '0',
                 counter: (Number(account.counter) + 1).toString(),
                 gas_limit: '120',
                 storage_limit: '0',
@@ -248,7 +247,7 @@ export namespace TezosOperations {
             source: keyStore.publicKeyHash,
             kind:   "transaction"
         };
-        const operations = await appendRevealOperation(network, keyStore, fee, account, [transaction])
+        const operations = await appendRevealOperation(network, keyStore, account, [transaction])
         return sendOperation(network, operations, keyStore, derivationPath)
     }
 
@@ -279,7 +278,7 @@ export namespace TezosOperations {
             gas_limit: '120',
             delegate: delegate
         }
-        const operations = await appendRevealOperation(network, keyStore, fee, account, [delegation])
+        const operations = await appendRevealOperation(network, keyStore, account, [delegation])
         return sendOperation(network, operations, keyStore, derivationPath)
     }
 
@@ -320,7 +319,7 @@ export namespace TezosOperations {
             delegatable: delegatable,
             delegate: delegate
         };
-        const operations = await appendRevealOperation(network, keyStore, fee, account, [origination])
+        const operations = await appendRevealOperation(network, keyStore, account, [origination])
         return sendOperation(network, operations, keyStore, derivationPath)
     }
 
@@ -354,7 +353,7 @@ export namespace TezosOperations {
         const revealOp: Object = {
             kind: "reveal",
             source: keyStore.publicKeyHash,
-            fee: fee.toString(),
+            fee: '0',
             counter: (Number(account.counter) + 1).toString(),
             gas_limit: '120',
             storage_limit: '0',


### PR DESCRIPTION
Fixes #64. Interestingly enough, while the source code between feature and develop are almost identical, feature has a counter_in_the_past warning on transactions consistently, whereas develop does not.