### PR TITLE
Add Estimation of Origination Operations in `TezosNodeWriter`

### DIFF
--- a/src/chain/tezos/TezosNodeWriter.ts
+++ b/src/chain/tezos/TezosNodeWriter.ts
@@ -676,7 +676,14 @@ export namespace TezosNodeWriter {
             counter
         )
 
-        return estimateOperation(server, chainid, transaction)
+        const resources = await estimateOperation(server, chainid, transaction)
+
+        // A fixed storage cost is applied to new contract originations which is not included in the estimation response.
+        const fixedOriginationStorageCost = 257
+        return {
+            gas: resources.gas,
+            storageCost: resources.storageCost + fixedOriginationStorageCost
+        }
     }
 
     /**
@@ -706,6 +713,12 @@ export namespace TezosNodeWriter {
         parseRPCError(responseText);
 
         const responseJSON = JSON.parse(responseText);
+
+        console.log("\n\n\n")
+        console.log("ESTIMATION RESPONSE: ")
+        console.log(JSON.stringify(responseJSON))
+        console.log("\n\n\n")
+
         let gas = 0;
         let storageCost = 0;
         for (let c of responseJSON['contents']) {

--- a/src/chain/tezos/TezosNodeWriter.ts
+++ b/src/chain/tezos/TezosNodeWriter.ts
@@ -682,12 +682,15 @@ export namespace TezosNodeWriter {
     /**
      * Dry run the given operation and return consumed resources. 
      * 
+     * Note: Estimating an operation on an unrevealed account is not supported and will fail.
+     *
+     * TODO: Add support for estimating multiple operations so that reveals can be processed.
+     * 
      * @param {string} server Tezos node to connect to
      * @param {string} chainid The chain ID to apply the operation on. 
      * @param {TezosP2PMessageTypes.Operation} operation The operation to estimate.
      * @returns A two-element object gas and storage costs. Throws an error if one was encountered.
      */
-    // TODO: Add support for multiple operations as this will fail if a reveal operation is required.
     export async function estimateOperation(
         server: string,
         chainid: string,

--- a/src/chain/tezos/TezosNodeWriter.ts
+++ b/src/chain/tezos/TezosNodeWriter.ts
@@ -590,16 +590,16 @@ export namespace TezosNodeWriter {
      * Operation dry-run to get consumed gas and storage numbers
      *
      * @param {string} server Tezos node to connect to
-     * @param {string} chainid 
+ * @param {string} chainid The chain ID to apply the operation on. 
      * @param {KeyStore} keyStore Key pair along with public key hash
-     * @param {string} to Contract address
+     * @param {string} contract Contract address
      * @param {number} amount Amount to transfer along with the invocation
      * @param {number} fee Operation fee
      * @param {string} derivationPath BIP44 Derivation Path if signed with hardware, empty if signed with software
      * @param {string} storage_limit Storage fee
      * @param {string} gas_limit Gas limit
-     * @param {string} entrypoint Contract entry point
-     * @param {string} parameters Contract arguments
+     * @param {string|undefined} entrypoint Contract entry point
+     * @param {string|undefined} parameters Contract arguments
      * @param {TezosParameterFormat} parameterFormat Contract argument format
      * @returns A two-element object gas and storage costs. Throws an error if one was encountered.
      */
@@ -617,49 +617,77 @@ export namespace TezosNodeWriter {
         parameterFormat: TezosTypes.TezosParameterFormat = TezosTypes.TezosParameterFormat.Micheline
     ): Promise<{ gas: number, storageCost: number }> {
         const counter = await TezosNodeReader.getCounterForAccount(server, keyStore.publicKeyHash) + 1;
-        const transaction = constructContractInvocationOperation(keyStore.publicKeyHash, counter, contract, amount, fee, storageLimit, gasLimit, entrypoint, parameters, parameterFormat);
+        const transaction = constructContractInvocationOperation(
+            keyStore.publicKeyHash,
+            counter,
+            contract,
+            amount,
+            fee,
+            storageLimit,
+            gasLimit,
+            entrypoint,
+            parameters,
+            parameterFormat
+        );
 
         return estimateOperation(server, chainid, transaction)
     }
 
-    // export async function testContractDeployOperation(
-    //     server: string,
-    //     chainid: string,
-    //     keyStore: KeyStore,
-    //     contract: string,
-    //     amount: number,
-    //     fee: number,
-    //     storageLimit: number,
-    //     gasLimit: number,
-    //     entrypoint: string | undefined,
-    //     parameters: string | undefined,
-    //     parameterFormat: TezosTypes.TezosParameterFormat = TezosTypes.TezosParameterFormat.Micheline
-    // ): Promise<{ gas: number, storageCost: number }> {
-    //     const counter = await TezosNodeReader.getCounterForAccount(server, keyStore.publicKeyHash) + 1;
-    //     const transaction = constructContractInvocationOperation(keyStore.publicKeyHash, counter, contract, amount, fee, storageLimit, gasLimit, entrypoint, parameters, parameterFormat);
+    /**
+     * Origination dry-run to get consumed gas and storage numbers
+     *
+     * @param {string} server Tezos node to connect to
+     * @param {string} chainid The chain ID to apply the operation on. 
+     * @param {KeyStore} keyStore Key pair along with public key hash
+     * @param {string} contract Contract address
+     * @param {number} amount Amount to transfer along with the invocation
+     * @param {number} fee Operation fee
+     * @param {number} storageLimit Storage fee
+     * @param {number} gasLimit Gas limit
+     * @param {string|undefined} entrypoint Contract entry point
+     * @param {string|undefined} parameters Contract arguments
+     * @param {TezosParameterFormat} parameterFormat Contract argument format
+     * @returns A two-element object gas and storage costs. Throws an error if one was encountered.
+     */
+    export async function testContractDeployOperation(
+        server: string,
+        chainid: string,
+        keyStore: KeyStore,
+        contract: string,
+        amount: number,
+        fee: number,
+        storageLimit: number,
+        gasLimit: number,
+        entrypoint: string | undefined,
+        parameters: string | undefined,
+        parameterFormat: TezosTypes.TezosParameterFormat = TezosTypes.TezosParameterFormat.Micheline
+    ): Promise<{ gas: number, storageCost: number }> {
+        const counter = await TezosNodeReader.getCounterForAccount(server, keyStore.publicKeyHash) + 1;
+        const transaction = constructContractInvocationOperation(
+            keyStore.publicKeyHash,
+            counter,
+            contract,
+            amount,
+            fee,
+            storageLimit,
+            gasLimit,
+            entrypoint,
+            parameters,
+            parameterFormat
+        );
 
-    //     return estimateOperation(server, chainid, transaction)
-    // }
-
+        return estimateOperation(server, chainid, transaction)
+    }
 
     /**
-        * Operation dry-run to get consumed gas and storage numbers
-        *
-        * @param {string} server Tezos node to connect to
-        * @param {string} chainid 
-        * @param {KeyStore} keyStore Key pair along with public key hash
-        * @param {string} to Contract address
-        * @param {number} amount Amount to transfer along with the invocation
-        * @param {number} fee Operation fee
-        * @param {string} derivationPath BIP44 Derivation Path if signed with hardware, empty if signed with software
-        * @param {string} storage_limit Storage fee
-        * @param {string} gas_limit Gas limit
-        * @param {string} entrypoint Contract entry point
-        * @param {string} parameters Contract arguments
-        * @param {TezosParameterFormat} parameterFormat Contract argument format
-        * @returns A two-element object gas and storage costs. Throws an error if one was encountered.
-        */
-    // TODO: Shouldn't htis take append.
+     * Dry run the given operation and return consumed resources. 
+     * 
+     * @param {string} server Tezos node to connect to
+     * @param {string} chainid The chain ID to apply the operation on. 
+     * @param {TezosP2PMessageTypes.Operation} operation The operation to estimate.
+     * @returns A two-element object gas and storage costs. Throws an error if one was encountered.
+     */
+    // TODO: Add support for multiple operations as this will fail if a reveal operation is required.
     export async function estimateOperation(
         server: string,
         chainid: string,

--- a/src/chain/tezos/TezosNodeWriter.ts
+++ b/src/chain/tezos/TezosNodeWriter.ts
@@ -381,40 +381,48 @@ export namespace TezosNodeWriter {
         storage: string,
         codeFormat: TezosTypes.TezosParameterFormat = TezosTypes.TezosParameterFormat.Micheline
     ) {
-
-
         const counter = await TezosNodeReader.getCounterForAccount(server, keyStore.publicKeyHash) + 1;
-
         const operation = constructContractOriginationOperation(
             keyStore,
-            fee,
-            counter,
             amount,
             delegate,
+            fee,
             storageLimit,
             gasLimit,
             code,
             storage,
-            codeFormat
+            codeFormat,
+            counter
         )
 
-
         const operations = await appendRevealOperation(server, keyStore, keyStore.publicKeyHash, counter - 1, [operation]);
-
         return sendOperation(server, operations, keyStore, derivationPath);
     }
 
+    /**
+     * Construct a contract origination operation. 
+     * 
+     * @param {KeyStore} keyStore Key pair along with public key hash
+     * @param {number} amount Initial funding amount of new account
+     * @param {string} delegate Account ID to delegate to, blank if none
+     * @param {number} fee Operation fee
+     * @param {number} storageLimit Storage fee
+     * @param {number} gasLimit Gas limit
+     * @param {string} code Contract code
+     * @param {string} storage Initial storage value
+     * @param {TezosParameterFormat} codeFormat Code format
+     */
     function constructContractOriginationOperation(
         keyStore: KeyStore,
-        fee: number,
-        counter: number,
         amount: number,
         delegate: string | undefined,
+        fee: number,
         storageLimit: number,
         gasLimit: number,
         code: string,
         storage: string,
-        codeFormat: TezosTypes.TezosParameterFormat
+        codeFormat: TezosTypes.TezosParameterFormat,
+        counter: number
     ): TezosP2PMessageTypes.Origination {
         let parsedCode: any = undefined;
         let parsedStorage: any = undefined;

--- a/src/chain/tezos/TezosNodeWriter.ts
+++ b/src/chain/tezos/TezosNodeWriter.ts
@@ -359,9 +359,9 @@ export namespace TezosNodeWriter {
      * @param {string} server Tezos node to connect to
      * @param {KeyStore} keyStore Key pair along with public key hash
      * @param {number} amount Initial funding amount of new account
-     * @param {string} delegate Account ID to delegate to, blank if none
+     * @param {string|undefined} delegate Account ID to delegate to, blank if none
      * @param {number} fee Operation fee
-     * @param {string} derivationPath BIP44 Derivation Path if signed with hardware, empty if signed with software
+     * @param {string|undefined} derivationPath BIP44 Derivation Path if signed with hardware, empty if signed with software
      * @param {number} storageLimit Storage fee
      * @param {number} gasLimit Gas limit
      * @param {string} code Contract code
@@ -404,7 +404,7 @@ export namespace TezosNodeWriter {
      * 
      * @param {KeyStore} keyStore Key pair along with public key hash
      * @param {number} amount Initial funding amount of new account
-     * @param {string} delegate Account ID to delegate to, blank if none
+     * @param {string|undefined} delegate Account ID to delegate to, blank if none
      * @param {number} fee Operation fee
      * @param {number} storageLimit Storage fee
      * @param {number} gasLimit Gas limit
@@ -590,7 +590,7 @@ export namespace TezosNodeWriter {
      * Operation dry-run to get consumed gas and storage numbers
      *
      * @param {string} server Tezos node to connect to
- * @param {string} chainid The chain ID to apply the operation on. 
+     * @param {string} chainid The chain ID to apply the operation on. 
      * @param {KeyStore} keyStore Key pair along with public key hash
      * @param {string} contract Contract address
      * @param {number} amount Amount to transfer along with the invocation
@@ -639,42 +639,42 @@ export namespace TezosNodeWriter {
      * @param {string} server Tezos node to connect to
      * @param {string} chainid The chain ID to apply the operation on. 
      * @param {KeyStore} keyStore Key pair along with public key hash
-     * @param {string} contract Contract address
-     * @param {number} amount Amount to transfer along with the invocation
+     * @param {number} amount Initial funding amount of new account
+     * @param {string|undefined} delegate Account ID to delegate to, blank if none
      * @param {number} fee Operation fee
      * @param {number} storageLimit Storage fee
      * @param {number} gasLimit Gas limit
-     * @param {string|undefined} entrypoint Contract entry point
-     * @param {string|undefined} parameters Contract arguments
-     * @param {TezosParameterFormat} parameterFormat Contract argument format
+     * @param {string} code Contract code
+     * @param {string} storage Initial storage value
+     * @param {TezosParameterFormat} codeFormat Code format
      * @returns A two-element object gas and storage costs. Throws an error if one was encountered.
      */
     export async function testContractDeployOperation(
         server: string,
         chainid: string,
         keyStore: KeyStore,
-        contract: string,
         amount: number,
+        delegate: string | undefined,
         fee: number,
         storageLimit: number,
         gasLimit: number,
-        entrypoint: string | undefined,
-        parameters: string | undefined,
-        parameterFormat: TezosTypes.TezosParameterFormat = TezosTypes.TezosParameterFormat.Micheline
+        code: string,
+        storage: string,
+        codeFormat: TezosTypes.TezosParameterFormat = TezosTypes.TezosParameterFormat.Micheline
     ): Promise<{ gas: number, storageCost: number }> {
         const counter = await TezosNodeReader.getCounterForAccount(server, keyStore.publicKeyHash) + 1;
-        const transaction = constructContractInvocationOperation(
-            keyStore.publicKeyHash,
-            counter,
-            contract,
+        const transaction = constructContractOriginationOperation(
+            keyStore,
             amount,
+            delegate,
             fee,
             storageLimit,
             gasLimit,
-            entrypoint,
-            parameters,
-            parameterFormat
-        );
+            code,
+            storage,
+            codeFormat,
+            counter
+        )
 
         return estimateOperation(server, chainid, transaction)
     }


### PR DESCRIPTION
Refactoring `TezosNodeWriter` to allow estimation operations on Contract deploys. Specifically:
- Pull estimation code into a generic method, `estimateOperation` which takes a generic operation. 
- Refactor invocation estimation to use the new method. 
- Pull origination operation construction logic into a helper method. 
- Refactor origination method to use new helper
- Create a new estimation method for contract origination using the new methods

This also includes minor documentation updates, specifically:
- Camel casing parameters of functions that are touched
- Updating JSDoc to have correct types
- Noting that estimation functions will fail for unrevealed accounts and adding  a TODO

Tested by:
- Using `npm link` to link this into one of my projects and verifying estimation returned reasonable results
- CI