### PR TITLE
Tally gas and storage from internal operations when estimating costs

### DIFF
--- a/src/chain/tezos/TezosNodeWriter.ts
+++ b/src/chain/tezos/TezosNodeWriter.ts
@@ -723,8 +723,11 @@ export namespace TezosNodeWriter {
                 storageCost += parseInt(c['metadata']['operation_result']['paid_storage_size_diff']) || 0;
             } catch { }
 
-            // Process internal operations.
+            // Process internal operations if they are present.
             const internalOperations = c['metadata']['internal_operation_results']
+            if (internalOperations === undefined) {
+                continue
+            }
             for (const internalOperation of internalOperations) {
                 const result = internalOperation['result']
                 gas += parseInt(result['consumed_gas']) || 0

--- a/src/chain/tezos/TezosNodeWriter.ts
+++ b/src/chain/tezos/TezosNodeWriter.ts
@@ -714,18 +714,22 @@ export namespace TezosNodeWriter {
 
         const responseJSON = JSON.parse(responseText);
 
-        console.log("\n\n\n")
-        console.log("ESTIMATION RESPONSE: ")
-        console.log(JSON.stringify(responseJSON))
-        console.log("\n\n\n")
-
         let gas = 0;
         let storageCost = 0;
         for (let c of responseJSON['contents']) {
+            // Process main operation.
             try {
-                gas = parseInt(c['metadata']['operation_result']['consumed_gas']) || 0;
-                storageCost = parseInt(c['metadata']['operation_result']['paid_storage_size_diff']) || 0;
+                gas += parseInt(c['metadata']['operation_result']['consumed_gas']) || 0;
+                storageCost += parseInt(c['metadata']['operation_result']['paid_storage_size_diff']) || 0;
             } catch { }
+
+            // Process internal operations.
+            const internalOperations = c['metadata']['internal_operation_results']
+            for (const internalOperation of internalOperations) {
+                const result = internalOperation['result']
+                gas += parseInt(result['consumed_gas']) || 0
+                storageCost += parseInt(result['paid_storage_size_diff']) || 0;
+            }
         }
 
         return { gas, storageCost };


### PR DESCRIPTION
Note: this PR builds on #288 

Inter-contract calls tally their gas and storage separately from the main operation. An example of a preapply RPC containing an internal operation can be seen here: https://gist.githubusercontent.com/keefertaylor/d630d84d52f0f53af963efb3dc688b6c/raw/42d0a75b55c47e5abceee830eca509a0cf56497c/gistfile1.txt.

This same operation whose pre-apply result is presented is put on chain here: https://you.better-call.dev/carthagenet/opg/ooxPJez4bguoTLwcQNF9dLGji3SX9qcVeCQDwwAppU7BoGqeg8w/contents.

Tested:
- Verified that gas estimates and storage failed on inter-contract calls
- Applied this fix to the code in ConseilJS
- Used `npm link` to pull in the fix to my program and verified the operation could be appled. 