### PR TITLE
Add Ability to Set / Clear Bakers for Ovens in Wrapped Tezos

### DIFF
--- a/src/chain/tezos/TezosMessageUtil.ts
+++ b/src/chain/tezos/TezosMessageUtil.ts
@@ -552,48 +552,4 @@ export namespace TezosMessageUtils {
 
         return n.toJSNumber();
     }
-
-    /**
-     * Calculate the address of a contract that was originated.
-     *
-     * @param operationHash The operation group hash.
-     * @param index The index of the origination operation in the operation group.
-     */
-    export function calculateContractAddress(operationHash: string, index: number): string {
-        // Decode and slice two byte prefix off operation hash.
-        const decoded: Uint8Array = base58check.decode(operationHash).slice(2)
-
-        // Merge the decoded buffer with the operation prefix.
-        let decodedAndOperationPrefix: Array<number> = []
-        for (let i = 0; i < decoded.length; i++) {
-            decodedAndOperationPrefix.push(decoded[i])
-        }
-        decodedAndOperationPrefix = decodedAndOperationPrefix.concat([
-            (index & 0xff000000) >> 24,
-            (index & 0x00ff0000) >> 16,
-            (index & 0x0000ff00) >> 8,
-            index & 0x000000ff,
-        ])
-
-        // Hash and encode.
-        const hash = blakejs.blake2b(new Uint8Array(decodedAndOperationPrefix), null, 20)
-        const smartContractAddressPrefix = new Uint8Array([2, 90, 121]) // KT1
-        const prefixedBytes = mergeBytes(smartContractAddressPrefix, hash)
-        return base58check.encode(prefixedBytes)
-    }
-
-    /**
-     * Helper to merge two Uint8Arrays.
-     * 
-     * @param a The first array.
-     * @param b The second array.
-     * @returns A new array that contains b appended to the end of a.
-     */
-    function mergeBytes(a: Uint8Array, b: Uint8Array): Uint8Array {
-        const merged = new Uint8Array(a.length + b.length)
-        merged.set(a)
-        merged.set(b, a.length)
-
-        return merged
-    }
 }

--- a/src/chain/tezos/TezosMessageUtil.ts
+++ b/src/chain/tezos/TezosMessageUtil.ts
@@ -552,4 +552,48 @@ export namespace TezosMessageUtils {
 
         return n.toJSNumber();
     }
+
+    /**	
+     * Calculate the address of a contract that was originated.	
+     *	
+     * @param operationHash The operation group hash.	
+     * @param index The index of the origination operation in the operation group.	
+     */
+    export function calculateContractAddress(operationHash: string, index: number): string {
+        // Decode and slice two byte prefix off operation hash.	
+        const decoded: Uint8Array = base58check.decode(operationHash).slice(2)
+
+        // Merge the decoded buffer with the operation prefix.	
+        let decodedAndOperationPrefix: Array<number> = []
+        for (let i = 0; i < decoded.length; i++) {
+            decodedAndOperationPrefix.push(decoded[i])
+        }
+        decodedAndOperationPrefix = decodedAndOperationPrefix.concat([
+            (index & 0xff000000) >> 24,
+            (index & 0x00ff0000) >> 16,
+            (index & 0x0000ff00) >> 8,
+            index & 0x000000ff,
+        ])
+
+        // Hash and encode.	
+        const hash = blakejs.blake2b(new Uint8Array(decodedAndOperationPrefix), null, 20)
+        const smartContractAddressPrefix = new Uint8Array([2, 90, 121]) // KT1	
+        const prefixedBytes = mergeBytes(smartContractAddressPrefix, hash)
+        return base58check.encode(prefixedBytes)
+    }
+
+    /**	
+     * Helper to merge two Uint8Arrays.	
+     * 	
+     * @param a The first array.	
+     * @param b The second array.	
+     * @returns A new array that contains b appended to the end of a.	
+     */
+    function mergeBytes(a: Uint8Array, b: Uint8Array): Uint8Array {
+        const merged = new Uint8Array(a.length + b.length)
+        merged.set(a)
+        merged.set(b, a.length)
+
+        return merged
+    }
 }

--- a/src/chain/tezos/TezosMessageUtil.ts
+++ b/src/chain/tezos/TezosMessageUtil.ts
@@ -553,17 +553,17 @@ export namespace TezosMessageUtils {
         return n.toJSNumber();
     }
 
-    /**	
-     * Calculate the address of a contract that was originated.	
-     *	
-     * @param operationHash The operation group hash.	
-     * @param index The index of the origination operation in the operation group.	
+    /**
+     * Calculate the address of a contract that was originated.
+     *
+     * @param operationHash The operation group hash.
+     * @param index The index of the origination operation in the operation group.
      */
     export function calculateContractAddress(operationHash: string, index: number): string {
-        // Decode and slice two byte prefix off operation hash.	
+        // Decode and slice two byte prefix off operation hash.
         const decoded: Uint8Array = base58check.decode(operationHash).slice(2)
 
-        // Merge the decoded buffer with the operation prefix.	
+        // Merge the decoded buffer with the operation prefix.
         let decodedAndOperationPrefix: Array<number> = []
         for (let i = 0; i < decoded.length; i++) {
             decodedAndOperationPrefix.push(decoded[i])
@@ -575,19 +575,19 @@ export namespace TezosMessageUtils {
             index & 0x000000ff,
         ])
 
-        // Hash and encode.	
+        // Hash and encode.
         const hash = blakejs.blake2b(new Uint8Array(decodedAndOperationPrefix), null, 20)
-        const smartContractAddressPrefix = new Uint8Array([2, 90, 121]) // KT1	
+        const smartContractAddressPrefix = new Uint8Array([2, 90, 121]) // KT1
         const prefixedBytes = mergeBytes(smartContractAddressPrefix, hash)
         return base58check.encode(prefixedBytes)
     }
 
-    /**	
-     * Helper to merge two Uint8Arrays.	
-     * 	
-     * @param a The first array.	
-     * @param b The second array.	
-     * @returns A new array that contains b appended to the end of a.	
+    /**
+     * Helper to merge two Uint8Arrays.
+     * 
+     * @param a The first array.
+     * @param b The second array.
+     * @returns A new array that contains b appended to the end of a.
      */
     function mergeBytes(a: Uint8Array, b: Uint8Array): Uint8Array {
         const merged = new Uint8Array(a.length + b.length)

--- a/src/chain/tezos/contracts/WrappedTezosHelper.ts
+++ b/src/chain/tezos/contracts/WrappedTezosHelper.ts
@@ -6,13 +6,13 @@ import { TezosMessageUtils } from '../TezosMessageUtil';
 import { TezosNodeReader } from '../TezosNodeReader';
 import { TezosNodeWriter } from '../TezosNodeWriter';
 import { TezosContractUtils } from './TezosContractUtils';
+import { TezosParameterFormat } from '../../../types/tezos/TezosChainTypes';
 
 /** The expected checksum for the Wrapped Tezos contracts. */
 const CONTRACT_CHECKSUMS = {
     token: 'd48b45bd77d2300026fe617c5ba7670e',
-    oven: '5e3c30607da21a0fc30f7be61afb15c7'
-
-    // TODO(keefertaylor): Implement additional checksums for core contract here.
+    oven: '5e3c30607da21a0fc30f7be61afb15c7',
+    core: '7b9b5b7e7f0283ff6388eb783e23c452'
 }
 
 /** The expected checksum for the Wrapped Tezos scripts. */
@@ -21,8 +21,19 @@ const SCRIPT_CHECKSUMS = {
     token: '',
     // TODO(keefertaylor): Compute this checksum correctly.
     oven: '',
+    // TODO(keefertaylor): Compute this checksum correctly.	
+    core: ''
+}
 
-    // TODO(keefertaylor): Implement additional checksums for core script here.
+/**	
+ * Property bag containing the results of opening an oven.	
+ */
+export type OpenOvenResult = {
+    // The operation hash of the request to open an oven.	
+    operationHash: string
+
+    // The address of the new oven contract.
+    ovenAddress: string
 }
 
 export interface WrappedTezosStorage {
@@ -67,18 +78,20 @@ export namespace WrappedTezosHelper {
      * @param nodeUrl The URL of the Tezos node which serves data.
      * @param tokenContractAddress The address of the token contract.
      * @param ovenContractAddress The address of an oven contract.
+     * @param coreContractAddress The address of the core contract.	     * 
      * @returns A boolean indicating if the code was the expected sum.
      */
     export async function verifyDestination(
         nodeUrl: string,
         tokenContractAddress: string,
-        ovenContractAddress: string
+        ovenContractAddress: string,
+        coreContractAddress: string
     ): Promise<boolean> {
-        // TODO(keefertaylor): Verify checksums for core contract here.
         const tokenMatched = TezosContractUtils.verifyDestination(nodeUrl, tokenContractAddress, CONTRACT_CHECKSUMS.token)
         const ovenMatched = TezosContractUtils.verifyDestination(nodeUrl, ovenContractAddress, CONTRACT_CHECKSUMS.oven)
+        const coreMatched = TezosContractUtils.verifyDestination(nodeUrl, coreContractAddress, CONTRACT_CHECKSUMS.core)
 
-        return tokenMatched && ovenMatched
+        return tokenMatched && ovenMatched && coreMatched
     }
 
     /**
@@ -88,14 +101,19 @@ export namespace WrappedTezosHelper {
      * 
      * @param tokenScript The script of the token contract.
      * @param ovenScript The script of an oven contract.
+     * @param coreScript The script of the core contract.
      * @returns A boolean indicating if the code was the expected sum.
      */
-    export function verifyScript(tokenScript: string, ovenScript: string): boolean {
-        // TODO(keefertaylor): Verify checksums for core script here.        
+    export function verifyScript(
+        tokenScript: string,
+        ovenScript: string,
+        coreScript: string
+    ): boolean {
         const tokenMatched = TezosContractUtils.verifyScript(tokenScript, SCRIPT_CHECKSUMS.token)
         const ovenMatched = TezosContractUtils.verifyScript(ovenScript, SCRIPT_CHECKSUMS.oven)
+        const coreMatched = TezosContractUtils.verifyScript(coreScript, SCRIPT_CHECKSUMS.core)
 
-        return tokenMatched && ovenMatched
+        return tokenMatched && ovenMatched && coreMatched
     }
 
     /**

--- a/src/chain/tezos/contracts/WrappedTezosHelper.ts
+++ b/src/chain/tezos/contracts/WrappedTezosHelper.ts
@@ -11,8 +11,9 @@ import { TezosParameterFormat } from '../../../types/tezos/TezosChainTypes';
 /** The expected checksum for the Wrapped Tezos contracts. */
 const CONTRACT_CHECKSUMS = {
     token: 'd48b45bd77d2300026fe617c5ba7670e',
-    oven: '5e3c30607da21a0fc30f7be61afb15c7',
-    core: '7b9b5b7e7f0283ff6388eb783e23c452'
+    oven: '5e3c30607da21a0fc30f7be61afb15c7'
+
+    // TODO(keefertaylor): Implement additional checksums for core contract here.
 }
 
 /** The expected checksum for the Wrapped Tezos scripts. */
@@ -20,20 +21,9 @@ const SCRIPT_CHECKSUMS = {
     // TODO(keefertaylor): Compute this checksum correctly.
     token: '',
     // TODO(keefertaylor): Compute this checksum correctly.
-    oven: '',
-    // TODO(keefertaylor): Compute this checksum correctly.
-    core: ''
-}
+    oven: ''
 
-/**
- * Property bag containing the results of opening an oven.
- */
-export type OpenOvenResult = {
-    // The operation hash of the request to open an oven.
-    operationHash: string
-
-    // The address of the new oven contract.
-    ovenAddress: string
+    // TODO(keefertaylor): Implement additional checksums for core script here.	
 }
 
 export interface WrappedTezosStorage {
@@ -267,42 +257,6 @@ export namespace WrappedTezosHelper {
         )
 
         return TezosContractUtils.clearRPCOperationGroupHash(nodeResult.operationGroupID);
-    }
-
-    export async function openOven(
-        nodeUrl: string,
-        signer: Signer,
-        keystore: KeyStore,
-        fee: number,
-        coreAddress: string,
-        gasLimit: number,
-        storageLimit: number
-    ): Promise<OpenOvenResult> {
-        const entryPoint = 'runEntrypointLambda'
-        const lambdaName = 'createOven'
-        const bytes = TezosMessageUtils.writePackedData(`Pair None "${keystore.publicKeyHash}"`, 'pair (option key_hash) address', TezosParameterFormat.Michelson)
-        const parameters = `Pair "${lambdaName}" 0x${bytes}`
-
-        const nodeResult = await TezosNodeWriter.sendContractInvocationOperation(
-            nodeUrl,
-            signer,
-            keystore,
-            coreAddress,
-            0,
-            fee,
-            storageLimit,
-            gasLimit,
-            entryPoint,
-            parameters,
-            TezosTypes.TezosParameterFormat.Michelson
-        )
-
-        const operationHash = TezosContractUtils.clearRPCOperationGroupHash(nodeResult.operationGroupID);
-        const ovenAddress = TezosMessageUtils.calculateContractAddress(operationHash, 0)
-        return {
-            operationHash,
-            ovenAddress
-        }
     }
 
     /**

--- a/src/chain/tezos/contracts/WrappedTezosHelper.ts
+++ b/src/chain/tezos/contracts/WrappedTezosHelper.ts
@@ -118,7 +118,7 @@ export namespace WrappedTezosHelper {
 
     /**
      *
-     * @param server	
+     * @param server
      * @param address
      */
     export async function getSimpleStorage(server: string, address: string): Promise<WrappedTezosStorage> {

--- a/src/chain/tezos/contracts/WrappedTezosHelper.ts
+++ b/src/chain/tezos/contracts/WrappedTezosHelper.ts
@@ -72,8 +72,7 @@ export namespace WrappedTezosHelper {
     export async function verifyDestination(
         nodeUrl: string,
         tokenContractAddress: string,
-        ovenContractAddress: string,
-        coreContractAddress: string
+        ovenContractAddress: string
     ): Promise<boolean> {
         // TODO(keefertaylor): Verify checksums for core contract here.
         const tokenMatched = TezosContractUtils.verifyDestination(nodeUrl, tokenContractAddress, CONTRACT_CHECKSUMS.token)
@@ -92,7 +91,7 @@ export namespace WrappedTezosHelper {
      * @returns A boolean indicating if the code was the expected sum.
      */
 
-    export function verifyScript(tokenScript: string, ovenScript, string, coreScript: string): boolean {
+    export function verifyScript(tokenScript: string, ovenScript: string): boolean {
         // TODO(keefertaylor): Verify checksums for core script here.        
         const tokenMatched = TezosContractUtils.verifyScript(tokenScript, SCRIPT_CHECKSUMS.token)
         const ovenMatched = TezosContractUtils.verifyScript(ovenScript, SCRIPT_CHECKSUMS.oven)

--- a/src/chain/tezos/contracts/WrappedTezosHelper.ts
+++ b/src/chain/tezos/contracts/WrappedTezosHelper.ts
@@ -6,7 +6,6 @@ import { TezosMessageUtils } from '../TezosMessageUtil';
 import { TezosNodeReader } from '../TezosNodeReader';
 import { TezosNodeWriter } from '../TezosNodeWriter';
 import { TezosContractUtils } from './TezosContractUtils';
-import { TezosParameterFormat } from '../../../types/tezos/TezosChainTypes';
 
 /** The expected checksum for the Wrapped Tezos contracts. */
 const CONTRACT_CHECKSUMS = {
@@ -21,9 +20,9 @@ const SCRIPT_CHECKSUMS = {
     // TODO(keefertaylor): Compute this checksum correctly.
     token: '',
     // TODO(keefertaylor): Compute this checksum correctly.
-    oven: ''
+    oven: '',
 
-    // TODO(keefertaylor): Implement additional checksums for core script here.	
+    // TODO(keefertaylor): Implement additional checksums for core script here.
 }
 
 export interface WrappedTezosStorage {
@@ -68,7 +67,6 @@ export namespace WrappedTezosHelper {
      * @param nodeUrl The URL of the Tezos node which serves data.
      * @param tokenContractAddress The address of the token contract.
      * @param ovenContractAddress The address of an oven contract.
-     * @param coreContractAddress The address of the core contract.
      * @returns A boolean indicating if the code was the expected sum.
      */
     export async function verifyDestination(
@@ -77,11 +75,11 @@ export namespace WrappedTezosHelper {
         ovenContractAddress: string,
         coreContractAddress: string
     ): Promise<boolean> {
+        // TODO(keefertaylor): Verify checksums for core contract here.
         const tokenMatched = TezosContractUtils.verifyDestination(nodeUrl, tokenContractAddress, CONTRACT_CHECKSUMS.token)
         const ovenMatched = TezosContractUtils.verifyDestination(nodeUrl, ovenContractAddress, CONTRACT_CHECKSUMS.oven)
-        const coreMatched = TezosContractUtils.verifyDestination(nodeUrl, coreContractAddress, CONTRACT_CHECKSUMS.core)
 
-        return tokenMatched && ovenMatched && coreMatched
+        return tokenMatched && ovenMatched
     }
 
     /**
@@ -91,16 +89,15 @@ export namespace WrappedTezosHelper {
      * 
      * @param tokenScript The script of the token contract.
      * @param ovenScript The script of an oven contract.
-     * @param coreScript The script of the core contract.
      * @returns A boolean indicating if the code was the expected sum.
      */
 
     export function verifyScript(tokenScript: string, ovenScript, string, coreScript: string): boolean {
+        // TODO(keefertaylor): Verify checksums for core script here.        
         const tokenMatched = TezosContractUtils.verifyScript(tokenScript, SCRIPT_CHECKSUMS.token)
         const ovenMatched = TezosContractUtils.verifyScript(ovenScript, SCRIPT_CHECKSUMS.oven)
-        const coreMatched = TezosContractUtils.verifyScript(coreScript, SCRIPT_CHECKSUMS.core)
 
-        return tokenMatched && ovenMatched && coreMatched
+        return tokenMatched && ovenMatched
     }
 
     /**

--- a/src/chain/tezos/contracts/WrappedTezosHelper.ts
+++ b/src/chain/tezos/contracts/WrappedTezosHelper.ts
@@ -78,7 +78,7 @@ export namespace WrappedTezosHelper {
      * @param nodeUrl The URL of the Tezos node which serves data.
      * @param tokenContractAddress The address of the token contract.
      * @param ovenContractAddress The address of an oven contract.
-     * @param coreContractAddress The address of the core contract. 
+     * @param coreContractAddress The address of the core contract.
      * @returns A boolean indicating if the code was the expected sum.
      */
     export async function verifyDestination(
@@ -116,10 +116,10 @@ export namespace WrappedTezosHelper {
         return tokenMatched && ovenMatched && coreMatched
     }
 
-    /**	
-     * 	
-     * @param server 	
-     * @param address 	
+    /**
+     *
+     * @param server	
+     * @param address
      */
     export async function getSimpleStorage(server: string, address: string): Promise<WrappedTezosStorage> {
         const storageResult = await TezosNodeReader.getContractStorage(server, address);
@@ -294,7 +294,7 @@ export namespace WrappedTezosHelper {
         return TezosContractUtils.clearRPCOperationGroupHash(nodeResult.operationGroupID);
     }
 
-    /**     
+    /**
      * Open a new oven.
      *
      * The oven's owner is assigned to the sender's address.
@@ -345,20 +345,20 @@ export namespace WrappedTezosHelper {
     }
 
     /**
-      * Set the baker for an oven.
-      * 
-      * This operation will fail if the sender is not the oven owner.
-      * 
-      * @param nodeUrl The URL of the Tezos node which serves data.
-      * @param signer A Signer for the sourceAddress.
-      * @param keystore A Keystore for the sourceAddress.
-      * @param fee The fee to use.
-      * @param gasLimit The gas limit to use.
-      * @param storageLimit The storage limit to use. 
-      * @param ovenAddress The address of the oven contract. 
-      * @param bakerAddress The address of the baker for the oven.
-      * @returns A string representing the operation hash.
-      */
+     * Set the baker for an oven.
+     * 
+     * This operation will fail if the sender is not the oven owner.
+     * 
+     * @param nodeUrl The URL of the Tezos node which serves data.
+     * @param signer A Signer for the sourceAddress.
+     * @param keystore A Keystore for the sourceAddress.
+     * @param fee The fee to use.
+     * @param gasLimit The gas limit to use.
+     * @param storageLimit The storage limit to use. 
+     * @param ovenAddress The address of the oven contract. 
+     * @param bakerAddress The address of the baker for the oven.
+     * @returns A string representing the operation hash.
+     */
     export async function setOvenBaker(
         nodeUrl: string,
         signer: Signer,

--- a/src/chain/tezos/contracts/WrappedTezosHelper.ts
+++ b/src/chain/tezos/contracts/WrappedTezosHelper.ts
@@ -21,15 +21,15 @@ const SCRIPT_CHECKSUMS = {
     token: '',
     // TODO(keefertaylor): Compute this checksum correctly.
     oven: '',
-    // TODO(keefertaylor): Compute this checksum correctly.	
+    // TODO(keefertaylor): Compute this checksum correctly.
     core: ''
 }
 
-/**	
- * Property bag containing the results of opening an oven.	
+/**
+ * Property bag containing the results of opening an oven.
  */
 export type OpenOvenResult = {
-    // The operation hash of the request to open an oven.	
+    // The operation hash of the request to open an oven.
     operationHash: string
 
     // The address of the new oven contract.
@@ -78,7 +78,7 @@ export namespace WrappedTezosHelper {
      * @param nodeUrl The URL of the Tezos node which serves data.
      * @param tokenContractAddress The address of the token contract.
      * @param ovenContractAddress The address of an oven contract.
-     * @param coreContractAddress The address of the core contract.	     * 
+     * @param coreContractAddress The address of the core contract. 
      * @returns A boolean indicating if the code was the expected sum.
      */
     export async function verifyDestination(
@@ -114,6 +114,28 @@ export namespace WrappedTezosHelper {
         const coreMatched = TezosContractUtils.verifyScript(coreScript, SCRIPT_CHECKSUMS.core)
 
         return tokenMatched && ovenMatched && coreMatched
+    }
+
+    /**	
+     * 	
+     * @param server 	
+     * @param address 	
+     */
+    export async function getSimpleStorage(server: string, address: string): Promise<WrappedTezosStorage> {
+        const storageResult = await TezosNodeReader.getContractStorage(server, address);
+
+        console.log(JSON.stringify(storageResult));
+
+        return {
+            balanceMap: Number(JSONPath({ path: '$.args[1].args[0].args[1].args[0].int', json: storageResult })[0]),
+            approvalsMap: Number(JSONPath({ path: '$.args[1].args[0].args[0].args[1].int', json: storageResult })[0]),
+            supply: Number(JSONPath({ path: '$.args[1].args[1].args[1].int', json: storageResult })[0]),
+            administrator: JSONPath({ path: '$.args[1].args[0].args[0].args[0].string', json: storageResult })[0],
+            paused: (JSONPath({ path: '$.args[1].args[1].args[0].prim', json: storageResult })[0]).toString().toLowerCase().startsWith('t'),
+            pauseGuardian: JSONPath({ path: '$.args[1].args[0].args[1].args[1].string', json: storageResult })[0],
+            outcomeMap: Number(JSONPath({ path: '$.args[0].args[0].int', json: storageResult })[0]),
+            swapMap: Number(JSONPath({ path: '$.args[0].args[1].int', json: storageResult })[0])
+        };
     }
 
     /**

--- a/src/chain/tezos/contracts/WrappedTezosHelper.ts
+++ b/src/chain/tezos/contracts/WrappedTezosHelper.ts
@@ -90,7 +90,6 @@ export namespace WrappedTezosHelper {
      * @param ovenScript The script of an oven contract.
      * @returns A boolean indicating if the code was the expected sum.
      */
-
     export function verifyScript(tokenScript: string, ovenScript: string): boolean {
         // TODO(keefertaylor): Verify checksums for core script here.        
         const tokenMatched = TezosContractUtils.verifyScript(tokenScript, SCRIPT_CHECKSUMS.token)


### PR DESCRIPTION
Add ability to set and clear delegates for oven.

Also contains some minor quality of life fixes (can be broken out at reviewer's request):
- Remove unused `getSimpleStorage` function
- Fix bug in `verifyScript` where `ovenScript` was unused
- Use "operation hash" rather than "transaction hash" consistently through file
- Use "account" rather than "address" consistently through file. 

Tested with this script: https://gist.github.com/keefertaylor/b8b4732f3ff870421d3960fe91102ec8
Sample output:
```
$ ts-node src/conseil-test.ts
========================================
SANITY CHECKS
========================================
Contract matched: true

========================================
OVEN CONTRACT
========================================
Delegated in hash: op1PPNnf9ygmda8deDe3WEHbWPFoQVgTraRgaE1dP2YQffHxyuY
sleeping for tx to be included...
good morning!

Undelegated in hash: onuBpL9RQutGJyi8egVSTxUbcVPKeU7A7EuskkghsqLWWrKTteY
```
