### PR TITLE
Generalize StakerDao's Tzip 7

### DIFF
--- a/src/chain/tezos/contracts/StakerDaoTzip7.ts
+++ b/src/chain/tezos/contracts/StakerDaoTzip7.ts
@@ -12,14 +12,13 @@ const CONTRACT_CHECKSUMS = {
   token: 'd48b45bd77d2300026fe617c5ba7670e',
 }
 
-/** The expected checksum for the Wrapped Tezos scripts. */
+/** The expected checksum for the StakerDao Tzip 7 script. */
 const SCRIPT_CHECKSUMS = {
   // TODO(keefertaylor): Compute this checksum correctly.
   token: '',
 }
 
-// TODO(keefertaylor): Rename
-export interface WrappedTezosStorage {
+export interface StakerDaoTzip7Storage {
   balanceMap: number;
   approvalsMap: number;
   supply: number;
@@ -30,10 +29,10 @@ export interface WrappedTezosStorage {
   swapMap: number;
 }
 
-export interface WrappedTezosBalanceRecord { }
-export interface WrappedTezosApprovalRecord { }
-export interface WrappedTezosOutcomeRecord { }
-export interface WrappedTezosSwapRecord { }
+export interface StakerDaoTzip7BalanceRecord { }
+export interface StakerDaoTzip7ApprovalRecord { }
+export interface StakerDaoTzip7OutcomeRecord { }
+export interface StakerDaoTzip7SwapRecord { }
 
 /**
  * Interface for a StakerDAO implementation of TZIP-7, AKA FA 1.2.
@@ -42,7 +41,7 @@ export interface WrappedTezosSwapRecord { }
  */
 export const StakerDaoTzip7 = {
   /**
-   * Verifies that contract code for Tzip 7 matches the expected code.
+   * Verifies that contract code for StakerDao's Tzip7 contract matches the expected code.
    * 
    * Note: This function processes contracts in the Micheline format.
    * 
@@ -58,7 +57,7 @@ export const StakerDaoTzip7 = {
   },
 
   /**
-   * Verifies that Michelson script for Wrapped Tezos contracts matches the expected code.
+   * Verifies that Michelson script for StakerDao's Tzip7 contract matches the expected code.
    * 
    * Note: This function processes scrips in Michelson format.
    * 
@@ -75,7 +74,7 @@ export const StakerDaoTzip7 = {
    * @param server
    * @param address
    */
-  getSimpleStorage: async function (server: string, address: string): Promise<WrappedTezosStorage> {
+  getSimpleStorage: async function (server: string, address: string): Promise<StakerDaoTzip7Storage> {
     const storageResult = await TezosNodeReader.getContractStorage(server, address);
 
     console.log(JSON.stringify(storageResult));

--- a/src/chain/tezos/contracts/StakerDaoTzip7.ts
+++ b/src/chain/tezos/contracts/StakerDaoTzip7.ts
@@ -54,7 +54,7 @@ export const StakerDaoTzip7 = {
     nodeUrl: string,
     tokenContractAddress: string
   ): Promise<boolean> {
-    return TezosContractUtils.verifyDestination(nodeUrl, tokenContractAddress, CONTRACT_CHECKSUMS.token)
+    return await TezosContractUtils.verifyDestination(nodeUrl, tokenContractAddress, CONTRACT_CHECKSUMS.token)
   },
 
   /**

--- a/src/chain/tezos/contracts/StakerDaoTzip7.ts
+++ b/src/chain/tezos/contracts/StakerDaoTzip7.ts
@@ -40,7 +40,7 @@ export interface WrappedTezosSwapRecord { }
  *
  * @author Keefer Taylor, Staker Services Ltd <keefer@stakerdao.com>
  */
-export namespace StakerDaoTzip7 {
+export const StakerDaoTzip7 = {
   /**
    * Verifies that contract code for Tzip 7 matches the expected code.
    * 
@@ -50,12 +50,12 @@ export namespace StakerDaoTzip7 {
    * @param tokenContractAddress The address of the token contract.
    * @returns A boolean indicating if the code was the expected sum.
    */
-  export async function verifyDestination(
+  verifyDestination: async function (
     nodeUrl: string,
     tokenContractAddress: string
   ): Promise<boolean> {
     return TezosContractUtils.verifyDestination(nodeUrl, tokenContractAddress, CONTRACT_CHECKSUMS.token)
-  }
+  },
 
   /**
    * Verifies that Michelson script for Wrapped Tezos contracts matches the expected code.
@@ -65,17 +65,17 @@ export namespace StakerDaoTzip7 {
    * @param tokenScript The script of the token contract.
    * @returns A boolean indicating if the code was the expected sum.
    */
-  export function verifyScript(
+  verifyScript: function (
     tokenScript: string,
   ): boolean {
     return TezosContractUtils.verifyScript(tokenScript, SCRIPT_CHECKSUMS.token)
-  }
+  },
 
   /**
    * @param server
    * @param address
    */
-  export async function getSimpleStorage(server: string, address: string): Promise<WrappedTezosStorage> {
+  getSimpleStorage: async function (server: string, address: string): Promise<WrappedTezosStorage> {
     const storageResult = await TezosNodeReader.getContractStorage(server, address);
 
     console.log(JSON.stringify(storageResult));
@@ -90,7 +90,7 @@ export namespace StakerDaoTzip7 {
       outcomeMap: Number(JSONPath({ path: '$.args[0].args[0].int', json: storageResult })[0]),
       swapMap: Number(JSONPath({ path: '$.args[0].args[1].int', json: storageResult })[0])
     };
-  }
+  },
 
   /**
    * Get the balance of tokens for an address.
@@ -100,7 +100,7 @@ export namespace StakerDaoTzip7 {
    * @param account The account to fetch the token balance for.
    * @returns The balance of the account.
    */
-  export async function getAccountBalance(server: string, mapid: number, account: string): Promise<number> {
+  getAccountBalance: async function (server: string, mapid: number, account: string): Promise<number> {
     const packedKey = TezosMessageUtils.encodeBigMapKey(Buffer.from(TezosMessageUtils.writePackedData(account, 'address'), 'hex'));
     const mapResult = await TezosNodeReader.getValueForBigMapKey(server, mapid, packedKey);
 
@@ -108,7 +108,7 @@ export namespace StakerDaoTzip7 {
 
     const numberString = JSONPath({ path: '$.int', json: mapResult });
     return Number(numberString);
-  }
+  },
 
   /**
    * Transfer some WXTZ between addresses.
@@ -125,7 +125,7 @@ export namespace StakerDaoTzip7 {
    * @param storageLimit The storage limit to use. 
    * @returns A string representing the operation hash.
    */
-  export async function transferBalance(
+  transferBalance: async function (
     nodeUrl: string,
     signer: Signer,
     keystore: KeyStore,

--- a/src/chain/tezos/contracts/StakerDaoTzip7.ts
+++ b/src/chain/tezos/contracts/StakerDaoTzip7.ts
@@ -1,0 +1,158 @@
+import { JSONPath } from 'jsonpath-plus';
+
+import { KeyStore, Signer } from '../../../types/ExternalInterfaces';
+import * as TezosTypes from '../../../types/tezos/TezosChainTypes';
+import { TezosMessageUtils } from '../TezosMessageUtil';
+import { TezosNodeReader } from '../TezosNodeReader';
+import { TezosNodeWriter } from '../TezosNodeWriter';
+import { TezosContractUtils } from './TezosContractUtils';
+
+/** The expected checksum for the StakerDao Tzip 7 contract. */
+const CONTRACT_CHECKSUMS = {
+  token: 'd48b45bd77d2300026fe617c5ba7670e',
+}
+
+/** The expected checksum for the Wrapped Tezos scripts. */
+const SCRIPT_CHECKSUMS = {
+  // TODO(keefertaylor): Compute this checksum correctly.
+  token: '',
+}
+
+// TODO(keefertaylor): Rename
+export interface WrappedTezosStorage {
+  balanceMap: number;
+  approvalsMap: number;
+  supply: number;
+  administrator: string;
+  paused: boolean;
+  pauseGuardian: string;
+  outcomeMap: number;
+  swapMap: number;
+}
+
+export interface WrappedTezosBalanceRecord { }
+export interface WrappedTezosApprovalRecord { }
+export interface WrappedTezosOutcomeRecord { }
+export interface WrappedTezosSwapRecord { }
+
+/**
+ * Interface for a StakerDAO implementation of TZIP-7, AKA FA 1.2.
+ *
+ * @author Keefer Taylor, Staker Services Ltd <keefer@stakerdao.com>
+ */
+export namespace StakerDaoTzip7 {
+  /**
+   * Verifies that contract code for Tzip 7 matches the expected code.
+   * 
+   * Note: This function processes contracts in the Micheline format.
+   * 
+   * @param nodeUrl The URL of the Tezos node which serves data.
+   * @param tokenContractAddress The address of the token contract.
+   * @returns A boolean indicating if the code was the expected sum.
+   */
+  export async function verifyDestination(
+    nodeUrl: string,
+    tokenContractAddress: string
+  ): Promise<boolean> {
+    return TezosContractUtils.verifyDestination(nodeUrl, tokenContractAddress, CONTRACT_CHECKSUMS.token)
+  }
+
+  /**
+   * Verifies that Michelson script for Wrapped Tezos contracts matches the expected code.
+   * 
+   * Note: This function processes scrips in Michelson format.
+   * 
+   * @param tokenScript The script of the token contract.
+   * @returns A boolean indicating if the code was the expected sum.
+   */
+  export function verifyScript(
+    tokenScript: string,
+  ): boolean {
+    return TezosContractUtils.verifyScript(tokenScript, SCRIPT_CHECKSUMS.token)
+  }
+
+  /**
+   * @param server
+   * @param address
+   */
+  export async function getSimpleStorage(server: string, address: string): Promise<WrappedTezosStorage> {
+    const storageResult = await TezosNodeReader.getContractStorage(server, address);
+
+    console.log(JSON.stringify(storageResult));
+
+    return {
+      balanceMap: Number(JSONPath({ path: '$.args[1].args[0].args[1].args[0].int', json: storageResult })[0]),
+      approvalsMap: Number(JSONPath({ path: '$.args[1].args[0].args[0].args[1].int', json: storageResult })[0]),
+      supply: Number(JSONPath({ path: '$.args[1].args[1].args[1].int', json: storageResult })[0]),
+      administrator: JSONPath({ path: '$.args[1].args[0].args[0].args[0].string', json: storageResult })[0],
+      paused: (JSONPath({ path: '$.args[1].args[1].args[0].prim', json: storageResult })[0]).toString().toLowerCase().startsWith('t'),
+      pauseGuardian: JSONPath({ path: '$.args[1].args[0].args[1].args[1].string', json: storageResult })[0],
+      outcomeMap: Number(JSONPath({ path: '$.args[0].args[0].int', json: storageResult })[0]),
+      swapMap: Number(JSONPath({ path: '$.args[0].args[1].int', json: storageResult })[0])
+    };
+  }
+
+  /**
+   * Get the balance of tokens for an address.
+   * 
+   * @param nodeUrl The URL of the Tezos node which serves data.
+   * @param mapId The ID of the BigMap which contains balances.
+   * @param account The account to fetch the token balance for.
+   * @returns The balance of the account.
+   */
+  export async function getAccountBalance(server: string, mapid: number, account: string): Promise<number> {
+    const packedKey = TezosMessageUtils.encodeBigMapKey(Buffer.from(TezosMessageUtils.writePackedData(account, 'address'), 'hex'));
+    const mapResult = await TezosNodeReader.getValueForBigMapKey(server, mapid, packedKey);
+
+    if (mapResult === undefined) { throw new Error(`Map ${mapid} does not contain a record for ${account}`); }
+
+    const numberString = JSONPath({ path: '$.int', json: mapResult });
+    return Number(numberString);
+  }
+
+  /**
+   * Transfer some WXTZ between addresses.
+   * 
+   * @param nodeUrl The URL of the Tezos node which serves data.
+   * @param signer A Signer for the sourceAddress.
+   * @param keystore A Keystore for the sourceAddress.
+   * @param tokenContractAddress The address of the token contract. 
+   * @param fee The fee to use.
+   * @param sourceAddress The address which will send tokens.
+   * @param destinationAddress The address which will receive tokens.
+   * @param amount The amount of tokens to send.
+   * @param gasLimit The gas limit to use.
+   * @param storageLimit The storage limit to use. 
+   * @returns A string representing the operation hash.
+   */
+  export async function transferBalance(
+    nodeUrl: string,
+    signer: Signer,
+    keystore: KeyStore,
+    tokenContractAddress: string,
+    fee: number,
+    sourceAddress: string,
+    destinationAddress: string,
+    amount: number,
+    gasLimit: number = 51_300,
+    storageLimit: number = 70
+  ): Promise<string> {
+    const parameters = `Pair "${sourceAddress}" (Pair "${destinationAddress}" ${amount})`;
+
+    const nodeResult = await TezosNodeWriter.sendContractInvocationOperation(
+      nodeUrl,
+      signer,
+      keystore,
+      tokenContractAddress,
+      0,
+      fee,
+      storageLimit,
+      gasLimit,
+      'transfer',
+      parameters,
+      TezosTypes.TezosParameterFormat.Michelson
+    );
+
+    return TezosContractUtils.clearRPCOperationGroupHash(nodeResult.operationGroupID);
+  }
+}

--- a/src/chain/tezos/contracts/WrappedTezosHelper.ts
+++ b/src/chain/tezos/contracts/WrappedTezosHelper.ts
@@ -61,7 +61,7 @@ export type OvenMapSchema = { key: string, value: string }
  *
  * @author Keefer Taylor, Staker Services Ltd <keefer@stakerdao.com>
  */
-namespace WrappedTezosHelperInternal {
+const WrappedTezosHelperInternal = {
     /**
      * Verifies that contract code for Wrapped Tezos matches the expected code.
      * 
@@ -73,18 +73,20 @@ namespace WrappedTezosHelperInternal {
      * @param coreContractAddress The address of the core contract.
      * @returns A boolean indicating if the code was the expected sum.
      */
-    export async function verifyDestination(
+    // TODO(keefertaylor): Properly handle async here.
+    verifyDestination: async function (
         nodeUrl: string,
         tokenContractAddress: string,
         ovenContractAddress: string,
         coreContractAddress: string
     ): Promise<boolean> {
+        // TODO(keefertaylor): Do not use StakerDaoTzip7 as a mixin.
         const tokenMatched = StakerDaoTzip7.verifyDestination(nodeUrl, tokenContractAddress)
         const ovenMatched = TezosContractUtils.verifyDestination(nodeUrl, ovenContractAddress, CONTRACT_CHECKSUMS.oven)
         const coreMatched = TezosContractUtils.verifyDestination(nodeUrl, coreContractAddress, CONTRACT_CHECKSUMS.core)
 
         return tokenMatched && ovenMatched && coreMatched
-    }
+    },
 
     /**
      * Verifies that Michelson script for Wrapped Tezos contracts matches the expected code.
@@ -96,17 +98,19 @@ namespace WrappedTezosHelperInternal {
      * @param coreScript The script of the core contract.
      * @returns A boolean indicating if the code was the expected sum.
      */
-    export function verifyScript(
+    // TODO(keefertaylor): Properly handle async here
+    verifyScript: function (
         tokenScript: string,
         ovenScript: string,
         coreScript: string
     ): boolean {
+        // TODO(keefertaylor): Do not use StakerDaoTzip7 as a mixin.
         const tokenMatched = StakerDaoTzip7.verifyScript(tokenScript)
         const ovenMatched = TezosContractUtils.verifyScript(ovenScript, SCRIPT_CHECKSUMS.oven)
         const coreMatched = TezosContractUtils.verifyScript(coreScript, SCRIPT_CHECKSUMS.core)
 
         return tokenMatched && ovenMatched && coreMatched
-    }
+    },
 
     /**
      * Deposit XTZ into an oven to mint WXTZ.
@@ -124,7 +128,7 @@ namespace WrappedTezosHelperInternal {
      * @param storageLimit The storage limit to use. 
      * @returns A string representing the operation hash.
      */
-    export async function depositToOven(
+    depositToOven: async function depositToOven(
         nodeUrl: string,
         signer: Signer,
         keystore: KeyStore,
@@ -151,7 +155,7 @@ namespace WrappedTezosHelperInternal {
         )
 
         return TezosContractUtils.clearRPCOperationGroupHash(nodeResult.operationGroupID);
-    }
+    },
 
     /**
      * Withdraw XTZ from an oven by repaying WXTZ.
@@ -171,7 +175,7 @@ namespace WrappedTezosHelperInternal {
      * @param storageLimit The storage limit to use. 
      * @returns A string representing the operation hash.
      */
-    export async function withdrawFromOven(
+    withdrawFromOven: async function (
         nodeUrl: string,
         signer: Signer,
         keystore: KeyStore,
@@ -198,7 +202,7 @@ namespace WrappedTezosHelperInternal {
         )
 
         return TezosContractUtils.clearRPCOperationGroupHash(nodeResult.operationGroupID);
-    }
+    },
 
     /**
      * Retrieve a list of all oven addresses a user owns.
@@ -208,7 +212,7 @@ namespace WrappedTezosHelperInternal {
      * @param ovenOwner The oven owner to search for
      * @param ovenListBigMapId The BigMap ID of the oven list.
      */
-    export async function listOvens(
+    listOven: async function (
         serverInfo: ConseilServerInfo,
         coreContractAddress: string,
         ovenOwner: string,
@@ -252,7 +256,7 @@ namespace WrappedTezosHelperInternal {
         return ownedOvens.map((oven: OvenMapSchema) => {
             return oven.key
         })
-    }
+    },
 
     /**
      * Open a new oven.
@@ -268,7 +272,7 @@ namespace WrappedTezosHelperInternal {
      * @param storageLimit The storage limit to use.
      * @returns A property bag of data about the operation.
      */
-    export async function openOven(
+    openOven: async function (
         nodeUrl: string,
         signer: Signer,
         keystore: KeyStore,
@@ -302,7 +306,7 @@ namespace WrappedTezosHelperInternal {
             operationHash,
             ovenAddress
         }
-    }
+    },
 
     /**
      * Set the baker for an oven.
@@ -319,7 +323,7 @@ namespace WrappedTezosHelperInternal {
      * @param storageLimit The storage limit to use. 
      * @returns A string representing the operation hash.
      */
-    export async function setOvenBaker(
+    setOvenBaker: async function (
         nodeUrl: string,
         signer: Signer,
         keystore: KeyStore,
@@ -346,8 +350,7 @@ namespace WrappedTezosHelperInternal {
         )
 
         return TezosContractUtils.clearRPCOperationGroupHash(nodeResult.operationGroupID);
-    }
-
+    },
 
     /**
      * Clear the baker for an oven.
@@ -363,7 +366,7 @@ namespace WrappedTezosHelperInternal {
      * @param storageLimit The storage limit to use. 
      * @returns A string representing the operation hash.
      */
-    export async function clearOvenBaker(
+    clearOvenBaker: async function (
         nodeUrl: string,
         signer: Signer,
         keystore: KeyStore,
@@ -393,5 +396,4 @@ namespace WrappedTezosHelperInternal {
 }
 
 /** Combine namespaces */
-const WrappedTezosHelper = WrappedTezosHelperInternal || StakerDaoTzip7
-export WrappedTezosHelper
+export const WrappedTezosHelper = StakerDaoTzip7 && WrappedTezosHelperInternal

--- a/src/chain/tezos/contracts/WrappedTezosHelper.ts
+++ b/src/chain/tezos/contracts/WrappedTezosHelper.ts
@@ -10,18 +10,16 @@ import { TezosConseilClient } from '../../../reporting/tezos/TezosConseilClient'
 import { ConseilServerInfo } from 'types/conseil/QueryTypes';
 import { ContractMapDetailsItem } from 'types/conseil/ConseilTezosTypes';
 import { TezosParameterFormat } from '../../../types/tezos/TezosChainTypes';
+import { StakerDaoTzip7 } from './StakerDaoTzip7';
 
 /** The expected checksum for the Wrapped Tezos contracts. */
 const CONTRACT_CHECKSUMS = {
-    token: 'd48b45bd77d2300026fe617c5ba7670e',
     oven: '5e3c30607da21a0fc30f7be61afb15c7',
     core: '7b9b5b7e7f0283ff6388eb783e23c452'
 }
 
 /** The expected checksum for the Wrapped Tezos scripts. */
 const SCRIPT_CHECKSUMS = {
-    // TODO(keefertaylor): Compute this checksum correctly.
-    token: '',
     // TODO(keefertaylor): Compute this checksum correctly.
     oven: '',
     // TODO(keefertaylor): Compute this checksum correctly.
@@ -38,22 +36,6 @@ export type OpenOvenResult = {
     // The address of the new oven contract.
     ovenAddress: string
 }
-
-export interface WrappedTezosStorage {
-    balanceMap: number;
-    approvalsMap: number;
-    supply: number;
-    administrator: string;
-    paused: boolean;
-    pauseGuardian: string;
-    outcomeMap: number;
-    swapMap: number;
-}
-
-export interface WrappedTezosBalanceRecord { }
-export interface WrappedTezosApprovalRecord { }
-export interface WrappedTezosOutcomeRecord { }
-export interface WrappedTezosSwapRecord { }
 
 /** 
  * Types for the Oven Map .
@@ -81,7 +63,7 @@ export type OvenMapSchema = { key: string, value: string }
  *
  * @author Keefer Taylor, Staker Services Ltd <keefer@stakerdao.com>
  */
-export namespace WrappedTezosHelper {
+namespace WrappedTezosHelperInternal {
     /**
      * Verifies that contract code for Wrapped Tezos matches the expected code.
      * 
@@ -99,7 +81,7 @@ export namespace WrappedTezosHelper {
         ovenContractAddress: string,
         coreContractAddress: string
     ): Promise<boolean> {
-        const tokenMatched = TezosContractUtils.verifyDestination(nodeUrl, tokenContractAddress, CONTRACT_CHECKSUMS.token)
+        const tokenMatched = StakerDaoTzip7.verifyDestination(nodeUrl, tokenContractAddress)
         const ovenMatched = TezosContractUtils.verifyDestination(nodeUrl, ovenContractAddress, CONTRACT_CHECKSUMS.oven)
         const coreMatched = TezosContractUtils.verifyDestination(nodeUrl, coreContractAddress, CONTRACT_CHECKSUMS.core)
 
@@ -121,97 +103,11 @@ export namespace WrappedTezosHelper {
         ovenScript: string,
         coreScript: string
     ): boolean {
-        const tokenMatched = TezosContractUtils.verifyScript(tokenScript, SCRIPT_CHECKSUMS.token)
+        const tokenMatched = StakerDaoTzip7.verifyScript(tokenScript)
         const ovenMatched = TezosContractUtils.verifyScript(ovenScript, SCRIPT_CHECKSUMS.oven)
         const coreMatched = TezosContractUtils.verifyScript(coreScript, SCRIPT_CHECKSUMS.core)
 
         return tokenMatched && ovenMatched && coreMatched
-    }
-
-    /**
-     *
-     * @param server
-     * @param address
-     */
-    export async function getSimpleStorage(server: string, address: string): Promise<WrappedTezosStorage> {
-        const storageResult = await TezosNodeReader.getContractStorage(server, address);
-
-        console.log(JSON.stringify(storageResult));
-
-        return {
-            balanceMap: Number(JSONPath({ path: '$.args[1].args[0].args[1].args[0].int', json: storageResult })[0]),
-            approvalsMap: Number(JSONPath({ path: '$.args[1].args[0].args[0].args[1].int', json: storageResult })[0]),
-            supply: Number(JSONPath({ path: '$.args[1].args[1].args[1].int', json: storageResult })[0]),
-            administrator: JSONPath({ path: '$.args[1].args[0].args[0].args[0].string', json: storageResult })[0],
-            paused: (JSONPath({ path: '$.args[1].args[1].args[0].prim', json: storageResult })[0]).toString().toLowerCase().startsWith('t'),
-            pauseGuardian: JSONPath({ path: '$.args[1].args[0].args[1].args[1].string', json: storageResult })[0],
-            outcomeMap: Number(JSONPath({ path: '$.args[0].args[0].int', json: storageResult })[0]),
-            swapMap: Number(JSONPath({ path: '$.args[0].args[1].int', json: storageResult })[0])
-        };
-    }
-
-    /**
-     * Get the balance of WXTZ tokens for an address.
-     * 
-     * @param nodeUrl The URL of the Tezos node which serves data.
-     * @param mapId The ID of the BigMap which contains balances.
-     * @param account The account to fetch the token balance for.
-     * @returns The balance of the account.
-     */
-    export async function getAccountBalance(server: string, mapid: number, account: string): Promise<number> {
-        const packedKey = TezosMessageUtils.encodeBigMapKey(Buffer.from(TezosMessageUtils.writePackedData(account, 'address'), 'hex'));
-        const mapResult = await TezosNodeReader.getValueForBigMapKey(server, mapid, packedKey);
-
-        if (mapResult === undefined) { throw new Error(`Map ${mapid} does not contain a record for ${account}`); }
-
-        const numberString = JSONPath({ path: '$.int', json: mapResult });
-        return Number(numberString);
-    }
-
-    /**
-     * Transfer some WXTZ between addresses.
-     * 
-     * @param nodeUrl The URL of the Tezos node which serves data.
-     * @param signer A Signer for the sourceAddress.
-     * @param keystore A Keystore for the sourceAddress.
-     * @param tokenContractAddress The address of the token contract. 
-     * @param fee The fee to use.
-     * @param sourceAddress The address which will send tokens.
-     * @param destinationAddress The address which will receive tokens.
-     * @param amount The amount of tokens to send.
-     * @param gasLimit The gas limit to use.
-     * @param storageLimit The storage limit to use. 
-     * @returns A string representing the operation hash.
-     */
-    export async function transferBalance(
-        nodeUrl: string,
-        signer: Signer,
-        keystore: KeyStore,
-        tokenContractAddress: string,
-        fee: number,
-        sourceAddress: string,
-        destinationAddress: string,
-        amount: number,
-        gasLimit: number = 51_300,
-        storageLimit: number = 70
-    ): Promise<string> {
-        const parameters = `Pair "${sourceAddress}" (Pair "${destinationAddress}" ${amount})`;
-
-        const nodeResult = await TezosNodeWriter.sendContractInvocationOperation(
-            nodeUrl,
-            signer,
-            keystore,
-            tokenContractAddress,
-            0,
-            fee,
-            storageLimit,
-            gasLimit,
-            'transfer',
-            parameters,
-            TezosTypes.TezosParameterFormat.Michelson
-        );
-
-        return TezosContractUtils.clearRPCOperationGroupHash(nodeResult.operationGroupID);
     }
 
     /**
@@ -497,3 +393,7 @@ export namespace WrappedTezosHelper {
         return TezosContractUtils.clearRPCOperationGroupHash(nodeResult.operationGroupID);
     }
 }
+
+/*** Combine namespaces */
+const WrappedTezosHelper = WrappedTezosHelperInternal || StakerDaoTzip7
+export WrappedTezosHelper

--- a/src/chain/tezos/contracts/WrappedTezosHelper.ts
+++ b/src/chain/tezos/contracts/WrappedTezosHelper.ts
@@ -61,14 +61,13 @@ const WrappedTezosHelperInternal = {
      * @param coreContractAddress The address of the core contract.
      * @returns A boolean indicating if the code was the expected sum.
      */
-    // TODO(keefertaylor): Properly handle async here.
     verifyDestination: async function (
         nodeUrl: string,
         ovenContractAddress: string,
         coreContractAddress: string
     ): Promise<boolean> {
-        const ovenMatched = TezosContractUtils.verifyDestination(nodeUrl, ovenContractAddress, CONTRACT_CHECKSUMS.oven)
-        const coreMatched = TezosContractUtils.verifyDestination(nodeUrl, coreContractAddress, CONTRACT_CHECKSUMS.core)
+        const ovenMatched = await TezosContractUtils.verifyDestination(nodeUrl, ovenContractAddress, CONTRACT_CHECKSUMS.oven)
+        const coreMatched = await TezosContractUtils.verifyDestination(nodeUrl, coreContractAddress, CONTRACT_CHECKSUMS.core)
 
         return ovenMatched && coreMatched
     },
@@ -83,7 +82,6 @@ const WrappedTezosHelperInternal = {
      * @param coreScript The script of the core contract.
      * @returns A boolean indicating if the code was the expected sum.
      */
-    // TODO(keefertaylor): Properly handle async here
     verifyScript: function (
         ovenScript: string,
         coreScript: string
@@ -407,15 +405,14 @@ export const WrappedTezosHelper = StakerDaoTzip7 && WrappedTezosHelperInternal &
      * @param coreContractAddress The address of the core contract.
      * @returns A boolean indicating if the code was the expected sum.
      */
-    // TODO(keefertaylor): Properly handle async here.
     verifyDestination: async function verifyDestination(
         nodeUrl: string,
         tokenContractAddress: string,
         ovenContractAddress: string,
         coreContractAddress: string
     ): Promise<boolean> {
-        const tokenMatched = StakerDaoTzip7.verifyDestination(nodeUrl, tokenContractAddress)
-        const wrappedTezosInternalMatched = WrappedTezosHelperInternal.verifyDestination(nodeUrl, ovenContractAddress, coreContractAddress)
+        const tokenMatched = await StakerDaoTzip7.verifyDestination(nodeUrl, tokenContractAddress)
+        const wrappedTezosInternalMatched = await WrappedTezosHelperInternal.verifyDestination(nodeUrl, ovenContractAddress, coreContractAddress)
 
         return tokenMatched && wrappedTezosInternalMatched
     },
@@ -430,7 +427,6 @@ export const WrappedTezosHelper = StakerDaoTzip7 && WrappedTezosHelperInternal &
      * @param coreScript The script of the core contract.
      * @returns A boolean indicating if the code was the expected sum.
      */
-    // TODO(keefertaylor): Properly handle async here.
     verifyScript: function (
         tokenScript: string,
         ovenScript: string,

--- a/src/chain/tezos/contracts/WrappedTezosHelper.ts
+++ b/src/chain/tezos/contracts/WrappedTezosHelper.ts
@@ -44,22 +44,9 @@ export type OpenOvenResult = {
 export type OvenMapSchema = { key: string, value: string }
 
 /**
- * Interface for the Wrapped XTZ Token and Oven implementation.
+ * Wrapped Tezos specific functions. 
  * 
- * @see {@link https://forum.tezosagora.org/t/wrapped-tezos/2195|wXTZ on Tezos Agora}
- * 
- * The token represented by these contracts trades with symbol 'WXTZ' and is specified with 10^-6 precision. Put
- * simply, 1 XTZ = 1 WXTZ, and 0.000_001 XTZ = 1 Mutez = 0.000_001 WXTZ.
- * 
- * Canonical Data:
- * - Delphinet:
- *  - Token Contract: KT1JYf7xjCJAqFDfNpuump9woSMaapy1WcMY 
- *  - Core Contract: KT1S98ELFTo6mdMBqhAVbGgKAVgLbdPP3AX8
- *  - Token Balances Map ID: 14566
- *  - Oven List Map ID: 14569
- * TODO(keefertaylor): Add additional data for mainnet here.
- *
- * @author Keefer Taylor, Staker Services Ltd <keefer@stakerdao.com>
+ * @see {WrappedTezosHelper}
  */
 const WrappedTezosHelperInternal = {
     /**
@@ -395,5 +382,22 @@ const WrappedTezosHelperInternal = {
     }
 }
 
-/** Combine namespaces */
+/**
+ * Interface for the Wrapped XTZ Token and Oven implementation.
+ * 
+ * @see {@link https://forum.tezosagora.org/t/wrapped-tezos/2195|wXTZ on Tezos Agora}
+ * 
+ * The token represented by these contracts trades with symbol 'WXTZ' and is specified with 10^-6 precision. Put
+ * simply, 1 XTZ = 1 WXTZ, and 0.000_001 XTZ = 1 Mutez = 0.000_001 WXTZ.
+ * 
+ * Canonical Data:
+ * - Delphinet:
+ *  - Token Contract: KT1JYf7xjCJAqFDfNpuump9woSMaapy1WcMY 
+ *  - Core Contract: KT1S98ELFTo6mdMBqhAVbGgKAVgLbdPP3AX8
+ *  - Token Balances Map ID: 14566
+ *  - Oven List Map ID: 14569
+ * TODO(keefertaylor): Add additional data for mainnet here.
+ *
+ * @author Keefer Taylor, Staker Services Ltd <keefer@stakerdao.com>
+ */
 export const WrappedTezosHelper = StakerDaoTzip7 && WrappedTezosHelperInternal

--- a/src/chain/tezos/contracts/WrappedTezosHelper.ts
+++ b/src/chain/tezos/contracts/WrappedTezosHelper.ts
@@ -1,9 +1,7 @@
-import { JSONPath } from 'jsonpath-plus';
 
 import { KeyStore, Signer } from '../../../types/ExternalInterfaces';
 import * as TezosTypes from '../../../types/tezos/TezosChainTypes';
 import { TezosMessageUtils } from '../TezosMessageUtil';
-import { TezosNodeReader } from '../TezosNodeReader';
 import { TezosNodeWriter } from '../TezosNodeWriter';
 import { TezosContractUtils } from './TezosContractUtils';
 import { TezosConseilClient } from '../../../reporting/tezos/TezosConseilClient'

--- a/src/chain/tezos/contracts/WrappedTezosHelper.ts
+++ b/src/chain/tezos/contracts/WrappedTezosHelper.ts
@@ -394,6 +394,6 @@ namespace WrappedTezosHelperInternal {
     }
 }
 
-/*** Combine namespaces */
+/** Combine namespaces */
 const WrappedTezosHelper = WrappedTezosHelperInternal || StakerDaoTzip7
 export WrappedTezosHelper


### PR DESCRIPTION
Generalize StakerDAO's Tzip 7 Implementation for re-use. 

The ultimate goal is to provide a wrapper for `BLND` which uses the same token contract as `WXTZ`. 

To accomplish this:
- Refactor token based functionality to a new helper file, and rename
- Convert `namespace` declarations to `objects`. This should be functionally the same to the client and there is no good way to merge namespaces (As far as this humble typescript developer can tell)
- Export a merged object of token functionality and wrapped tezos functionality. Note that object props after `&&` override the former. Ex:
```js
const a = {
  foo: function() { return "A" }
}

const b = {
  foo: function() { return "B" }
}

const c = a && b

a.foo() // "A"
b.foo() // "B"
c.foo() // "B"
```

-----

*Note: Please merge after #335. There's no way to diffbase this branch on this PR*.