### PR TITLE
Allow Setting a Baker when an Oven is Deployed

### DIFF
--- a/src/chain/tezos/contracts/WrappedTezosHelper.ts
+++ b/src/chain/tezos/contracts/WrappedTezosHelper.ts
@@ -387,8 +387,8 @@ export namespace WrappedTezosHelper {
     ): Promise<OpenOvenResult> {
         const entryPoint = 'runEntrypointLambda'
         const lambdaName = 'createOven'
-        const bakerParam = baker ?? 'None'
-        const bytes = TezosMessageUtils.writePackedData(`Pair "${bakerParam}" "${keystore.publicKeyHash}"`, 'pair (option key_hash) address', TezosParameterFormat.Michelson)
+        const bakerParam = baker !== undefined ? `Some "${baker}"` : 'None'
+        const bytes = TezosMessageUtils.writePackedData(`Pair ${bakerParam} "${keystore.publicKeyHash}"`, 'pair (option key_hash) address', TezosParameterFormat.Michelson)
         const parameters = `Pair "${lambdaName}" 0x${bytes}`
 
         const nodeResult = await TezosNodeWriter.sendContractInvocationOperation(

--- a/src/chain/tezos/contracts/WrappedTezosHelper.ts
+++ b/src/chain/tezos/contracts/WrappedTezosHelper.ts
@@ -375,7 +375,7 @@ export namespace WrappedTezosHelper {
      * @param storageLimit The storage limit to use.
      * @returns A property bag of data about the operation.
      */
-    export async function deplyOven(
+    export async function deployOven(
         nodeUrl: string,
         signer: Signer,
         keystore: KeyStore,

--- a/src/chain/tezos/contracts/WrappedTezosHelper.ts
+++ b/src/chain/tezos/contracts/WrappedTezosHelper.ts
@@ -361,7 +361,7 @@ export namespace WrappedTezosHelper {
     }
 
     /**
-     * Open a new oven.
+     * Deploy a new oven contract.
      *
      * The oven's owner is assigned to the sender's address.
      *
@@ -370,22 +370,25 @@ export namespace WrappedTezosHelper {
      * @param keystore A Keystore for the sourceAddress.
      * @param fee The fee to use.
      * @param coreAddress The address of the core contract.
+     * @param baker The inital baker for the Oven. If `undefined` the oven will not have an initial baker. Defaults to `undefined`.
      * @param gasLimit The gas limit to use.
      * @param storageLimit The storage limit to use.
      * @returns A property bag of data about the operation.
      */
-    export async function openOven(
+    export async function deplyOven(
         nodeUrl: string,
         signer: Signer,
         keystore: KeyStore,
         fee: number,
         coreAddress: string,
+        baker: string | undefined = undefined,
         gasLimit: number = 115_000,
         storageLimit: number = 1100
     ): Promise<OpenOvenResult> {
         const entryPoint = 'runEntrypointLambda'
         const lambdaName = 'createOven'
-        const bytes = TezosMessageUtils.writePackedData(`Pair None "${keystore.publicKeyHash}"`, 'pair (option key_hash) address', TezosParameterFormat.Michelson)
+        const bakerParam = baker ?? 'None'
+        const bytes = TezosMessageUtils.writePackedData(`Pair "${bakerParam}" "${keystore.publicKeyHash}"`, 'pair (option key_hash) address', TezosParameterFormat.Michelson)
         const parameters = `Pair "${lambdaName}" 0x${bytes}`
 
         const nodeResult = await TezosNodeWriter.sendContractInvocationOperation(


### PR DESCRIPTION
Minor improvements for UX:
- Allow users to set a delegate for an oven at deploy time
- Rename `openOven` to `deployOven` to better reflect what is happening in the operation

Testing done via script: https://gist.github.com/keefertaylor/9a9e1eae1ed3aa0845fe11e6ecff3126
Sample Output:

```shell
$ ts-node src/conseil-test.ts

========================================
SANITY CHECKS
========================================
Contract matched: true

========================================
CORE CONTRACT
========================================
Opened a vault in hash: ooKG9FBTtSNBcp9WBrZGMJhrHLuNgwzwQnJW9zWvDxVNfugTdBy
New address: KT1VduAoNFPRLEJJgRiJHCsuveCxQWPTgfvL
sleeping for tx to be included...
good morning!

Opened a vault in hash: onvH6N2UkhrQxiSfkxYD2k2BiQrtLoQ7L71CUucEwMR1TsU79vw
New address: KT19SAzLJSLK5bUiaZXTYwGM8uq52CCTU42q
```