### PR TITLE
[parser] - Normalize primitive objects of michelson JSON before parsing it.

### DIFF
--- a/src/chain/tezos/TezosLanguageUtil.ts
+++ b/src/chain/tezos/TezosLanguageUtil.ts
@@ -4,6 +4,8 @@ import * as nearley from 'nearley';
 
 import { TezosMessageUtils } from './TezosMessageUtil';
 
+const primitiveRecordOrder = ["prim", "args", "annots"];
+
 /**
  * A collection of functions to encode and decode Michelson and Micheline code
  */
@@ -428,6 +430,27 @@ export namespace TezosLanguageUtil {
         const parts: string[] = [sections['parameter'], sections['storage'], sections['code']];
 
         return parts.map(p => p.trim().split('\n').map(l => l.replace(/\#[\s\S]+$/, '').trim()).filter(v => v.length > 0).join(' '));
+    }
+
+    /**
+     * This util function is used to ensure the correct order in primitive records before parsing it.
+     *
+     * Micheline parser expects the following JSON order { prim: ..., args: ..., annots: ... }
+     */
+    export function normalizePrimitiveRecordOrder(obj: object)  {
+        if (Array.isArray(obj)) {
+            return obj.map(normalizePrimitiveRecordOrder);
+        }
+
+        if (typeof obj === "object") {
+            return Object.keys(obj)
+                .sort((k1, k2) => primitiveRecordOrder.indexOf(k1) - primitiveRecordOrder.indexOf(k2))
+                .reduce((newObj, key) => ({
+                    ...newObj,
+                    [key]: normalizePrimitiveRecordOrder(obj[key])
+                }), {});
+        }
+        return obj;
     }
 
     /**

--- a/src/chain/tezos/TezosMessageCodec.ts
+++ b/src/chain/tezos/TezosMessageCodec.ts
@@ -601,11 +601,12 @@ export namespace TezosMessageCodec {
         }
 
         if (!!origination.script) {
-            let parts: string[] = [];
+            let parts: object[] = [];
             parts.push(origination.script['code']); // full contract definition containing code, storage and parameters properties
             parts.push(origination.script['storage']); // initial storage
 
             hex += parts
+                .map(TezosLanguageUtil.normalizePrimitiveRecordOrder)
                 .map(p => TezosLanguageUtil.normalizeMichelineWhiteSpace(JSON.stringify(p)))
                 .map(p =>  TezosLanguageUtil.translateMichelineToHex(p))
                 .reduce((m, p) => { return m + ('0000000' + (p.length / 2).toString(16)).slice(-8) + p; }, '');

--- a/test/chain/tezos/TezosLanguageUtil.spec.ts
+++ b/test/chain/tezos/TezosLanguageUtil.spec.ts
@@ -303,6 +303,80 @@ describe("Tezos Michelson/Micheline fragment codec", () => {
         let result = TezosLanguageUtil.translateMichelineToHex(params);
         expect(result).to.equal('010000000568656c6c6f');
     });
+
+    it('Normalize Michelson JSON primitive record', () => {
+        let input = {
+            "prim": "parameter",
+            "args": [
+                {
+                    "prim": "list",
+                    "args": [
+                        {
+                            "prim": "pair",
+                            "args": [
+                                {
+                                    "prim": "sapling_transaction",
+                                    "annots": ["%transaction"],
+                                    "args": [
+                                        {
+                                            "int":"8"
+                                        }
+                                    ],
+                                },
+                                {
+                                    "prim": "option",
+                                    "annots": ["%key"],
+                                    "args": [
+                                        {
+                                            "prim":"key_hash"
+                                        }
+                                    ],
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        };
+        let expectedOutput = {
+            "prim": "parameter",
+            "args": [
+                {
+                    "prim": "list",
+                    "args": [
+                        {
+                            "prim": "pair",
+                            "args": [
+                                {
+                                    "prim": "sapling_transaction",
+                                    "args": [
+                                        {
+                                            "int":"8"
+                                        }
+                                    ],
+                                    "annots": ["%transaction"],
+                                },
+                                {
+                                    "prim": "option",
+                                    "args": [
+                                        {
+                                            "prim":"key_hash"
+                                        }
+                                    ],
+                                    "annots": ["%key"],
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        };
+
+        /**
+         * Ensure that { prim: ..., annots: ..., args: ... } is ordered to => { prim: ..., args: ..., annots: ... }
+         */
+        expect(JSON.stringify(TezosLanguageUtil.normalizePrimitiveRecordOrder(input))).equal(JSON.stringify(expectedOutput));
+    });
 });
 
 function preProcessMicheline(code: string): string[] {


### PR DESCRIPTION
The parser seems to be very strict and enforces a specific JSON format.

The JSON at the bottom would fail with `  [ { "prim": "parameter", "args": [ { "prim": "list", "args": [ { "prim": "pair", "args": [ { "prim": "sapling_transaction", "annots": [ "%transaction" ],
                                                                                                                                                          ^
Unexpected comma token: ",". Instead, I was expecting to see one of the following:
A _ token based on:`

Because `annots` was in the middle and the parser expects it to be the last key.

I had a fix for the parser, but ended up deleting it. (normalizing the order seems to be cleaner)

```json
{
            "prim": "parameter",
            "args": [
                {
                    "prim": "list",
                    "args": [
                        {
                            "prim": "pair",
                            "args": [
                                {
                                    "prim": "sapling_transaction",
                                    "annots": ["%transaction"],
                                    "args": [
                                        {
                                            "int":"8"
                                        }
                                    ],
                                },
                                {
                                    "prim": "option",
                                    "annots": ["%key"],
                                    "args": [
                                        {
                                            "prim":"key_hash"
                                        }
                                    ],
                                }
                            ]
                        }
                    ]
                }
            ]
        }
```