### PR TITLE
Ability to execute on-chain views

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conseiljs",
-  "version": "5.2.3",
+  "version": "5.2.6",
   "description": "Client-side library for Tezos dApp development.",
   "browser": "dist/index-web.js",
   "main": "dist/index.js",

--- a/src/chain/tezos/TezosNodeWriter.ts
+++ b/src/chain/tezos/TezosNodeWriter.ts
@@ -973,7 +973,7 @@ export namespace TezosNodeWriter {
         server: string,
         chainid: string,
         view_name: string,
-        view_input: string,
+        view_input: any,
         chain_id: string = 'NetXdQprcVkpaWU',
     ): Promise<any> {
         const response = await performPostRequest(

--- a/src/chain/tezos/TezosNodeWriter.ts
+++ b/src/chain/tezos/TezosNodeWriter.ts
@@ -15,7 +15,6 @@ import FetchSelector from '../../utils/FetchSelector'
 const fetch = FetchSelector.fetch;
 
 import LogSelector from '../../utils/LoggerSelector';
-import {block} from "../../../test/reporting/tezos/TezosConseilClient.responses";
 const log = LogSelector.log;
 const counterMatcher = new RegExp(/.*Counter [0-9]{1,} already used for contract.*/, 'gm');
 

--- a/src/chain/tezos/TezosNodeWriter.ts
+++ b/src/chain/tezos/TezosNodeWriter.ts
@@ -964,6 +964,7 @@ export namespace TezosNodeWriter {
      * @param {string} server Tezos node to connect to
      * @param {string} chainid The chain ID to apply the operation on, should be "main" or "test", not to be confused with chain_id.
      * @param {TezosP2PMessageTypes.Operation} operations A set of operations to update.
+     * @param {string} contract_address The address of the view's contract.
      * @param {string} view_name The view to run
      * @param {string} view_input The input to provide to the view
      * @param {string} chain_id The chain id hash, not to be confused with chainid. Default is mainnet chain_id, NetXdQprcVkpaWU.
@@ -972,6 +973,7 @@ export namespace TezosNodeWriter {
     export async function runView(
         server: string,
         chainid: string,
+        contract_address: string,
         view_name: string,
         view_input: any,
         chain_id: string = 'NetXdQprcVkpaWU',
@@ -980,7 +982,7 @@ export namespace TezosNodeWriter {
             server,
             `chains/${chainid}/blocks/head/helpers/scripts/run_script_view`,
             {
-                        "contract": "KT1LxPGwkrvj8gG8k8CkpyKQaWyQAsnLfHLg",
+                        "contract": contract_address,
                         "view": view_name,
                         "input": view_input,
                         "chain_id": chain_id,

--- a/src/chain/tezos/TezosNodeWriter.ts
+++ b/src/chain/tezos/TezosNodeWriter.ts
@@ -15,6 +15,7 @@ import FetchSelector from '../../utils/FetchSelector'
 const fetch = FetchSelector.fetch;
 
 import LogSelector from '../../utils/LoggerSelector';
+import {block} from "../../../test/reporting/tezos/TezosConseilClient.responses";
 const log = LogSelector.log;
 const counterMatcher = new RegExp(/.*Counter [0-9]{1,} already used for contract.*/, 'gm');
 
@@ -968,6 +969,7 @@ export namespace TezosNodeWriter {
      * @param {string} view_name The view to run
      * @param {string} view_input The input to provide to the view
      * @param {string} chain_id The chain id hash, not to be confused with chainid. Default is mainnet chain_id, NetXdQprcVkpaWU.
+     * @param {string} block_level The block level at which to run the specified view
      * @returns {Promise<any>} JSON-encoded response
      */
     export async function runView(
@@ -976,6 +978,7 @@ export namespace TezosNodeWriter {
         contract_address: string,
         view_name: string,
         view_input: any,
+        block_level: string,
         chain_id: string = 'NetXdQprcVkpaWU',
     ): Promise<any> {
         const response = await performPostRequest(
@@ -986,7 +989,8 @@ export namespace TezosNodeWriter {
                         "view": view_name,
                         "input": view_input,
                         "chain_id": chain_id,
-                        "unparsing_mode": "Readable"
+                        "unparsing_mode": "Readable",
+                        "level": block_level
             }
         );
         const responseText = await response.text();

--- a/src/chain/tezos/TezosNodeWriter.ts
+++ b/src/chain/tezos/TezosNodeWriter.ts
@@ -957,4 +957,42 @@ export namespace TezosNodeWriter {
 
         return ''; // applied
     }
+
+    /**
+     * Get the result of a smart contract view using the Tezos node's `run_script_view` RPC.
+     *
+     * @param {string} server Tezos node to connect to
+     * @param {string} chainid The chain ID to apply the operation on, should be "main" or "test", not to be confused with chain_id.
+     * @param {TezosP2PMessageTypes.Operation} operations A set of operations to update.
+     * @param {string} view_name The view to run
+     * @param {string} view_input The input to provide to the view
+     * @param {string} chain_id The chain id hash, not to be confused with chainid. Default is mainnet chain_id, NetXdQprcVkpaWU.
+     * @returns {Promise<any>} JSON-encoded response
+     */
+    export async function runView(
+        server: string,
+        chainid: string,
+        view_name: string,
+        view_input: string,
+        chain_id: string = 'NetXdQprcVkpaWU',
+    ): Promise<any> {
+        const response = await performPostRequest(
+            server,
+            `chains/${chainid}/blocks/head/helpers/scripts/run_script_view`,
+            {
+                        "contract": "KT1LxPGwkrvj8gG8k8CkpyKQaWyQAsnLfHLg",
+                        "view": view_name,
+                        "input": view_input,
+                        "chain_id": chain_id,
+                        "unparsing_mode": "Readable"
+            }
+        );
+        const responseText = await response.text();
+
+        parseRPCError(responseText);
+
+        const responseJSON = JSON.parse(responseText);
+
+        return responseJSON;
+    }
 }

--- a/src/chain/tezos/TezosNodeWriter.ts
+++ b/src/chain/tezos/TezosNodeWriter.ts
@@ -993,11 +993,7 @@ export namespace TezosNodeWriter {
             }
         );
         const responseText = await response.text();
-
-        parseRPCError(responseText);
-
         const responseJSON = JSON.parse(responseText);
-
         return responseJSON;
     }
 }


### PR DESCRIPTION
Using the `run_script_view` RPC, ConseilJS should now be able to get view invocation results. 