### PR TITLE
Await json before logging response

### DIFF
--- a/src/chain/tezos/TezosNodeReader.ts
+++ b/src/chain/tezos/TezosNodeReader.ts
@@ -31,8 +31,8 @@ export namespace TezosNodeReader {
                 }
                 return response;
             })
-            .then(response => {
-                const json: any = response.json();
+            .then(async response => {
+                const json: any = await response.json();
                 log.debug(`TezosNodeReader.performGetRequest response: ${json} for ${command} on ${server}`);
                 return json;
             });


### PR DESCRIPTION
I'm not sure if this is wanted since it will be very noisy, but it would stop us from having this output in the logs:

`TezosNodeReader.performGetRequest response: [object Promise] for chains/main/mempool/pending_operations on https://mainnet.tezos.marigold.dev`